### PR TITLE
Add missing closing angle bracket in doc

### DIFF
--- a/doc/Reprojucer.cmake/command/jucer_project_settings.rst
+++ b/doc/Reprojucer.cmake/command/jucer_project_settings.rst
@@ -24,5 +24,5 @@ Define the settings specific to a JUCE project.
     [BINARYDATACPP_SIZE_LIMIT <binarydatacpp_size_limit>]
     [BINARYDATA_NAMESPACE <binarydata_namespace>]
     [PREPROCESSOR_DEFINITIONS <preprocessor_definitions>]
-    [HEADER_SEARCH_PATHS <header_search_paths]
+    [HEADER_SEARCH_PATHS <header_search_paths>]
   )


### PR DESCRIPTION
This should have been done in 3db7295ad0b78dcd1c690eaa65c085fd81d4bc97.

@lethal-guitar, @MartyLake: FYI (no need to review) 
  