### PR TITLE
Fix issue with build failing on Linux with g++ v7+ due to implicit fallthrough warnings in juce-core module.

### DIFF
--- a/Jucer2Reprojucer/CMakeLists.txt
+++ b/Jucer2Reprojucer/CMakeLists.txt
@@ -207,6 +207,7 @@ jucer_export_target(
     "-Werror"
     "-Wall"
     "-Wextra"
+    "-Wno-implicit-fallthrough"
 )
 
 jucer_export_target_configuration(


### PR DESCRIPTION

Fix for issue #347.