### PR TITLE
Use one target per plugin format on Windows with JUCE 4 as well

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1462,21 +1462,6 @@ function(jucer_project_end)
     _FRUT_set_custom_xcode_flags(${target})
 
   elseif(JUCER_PROJECT_TYPE STREQUAL "Audio Plug-in")
-    if(NOT APPLE AND DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
-      add_library(${target} MODULE ${all_sources})
-      set_target_properties(${target} PROPERTIES PREFIX "")
-      _FRUT_set_output_directory_properties(${target} "")
-      _FRUT_set_common_target_properties(${target})
-
-      if(JUCER_BUILD_VST3 AND MSVC)
-        add_custom_command(TARGET ${target} POST_BUILD
-          COMMAND
-          "${CMAKE_COMMAND}" "-E" "copy_if_different"
-          "$<TARGET_FILE:${target}>"
-          "$<TARGET_FILE_DIR:${target}>/${target}.vst3"
-        )
-      endif()
-    else()
       unset(AudioUnit_sources)
       unset(AudioUnitv3_sources)
       unset(AAX_sources)
@@ -1905,7 +1890,6 @@ function(jucer_project_end)
         _FRUT_set_custom_xcode_flags(${aax_target})
         unset(aax_target)
       endif()
-    endif()
 
   else()
     message(FATAL_ERROR "Unknown project type: ${JUCER_PROJECT_TYPE}")

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1486,8 +1486,8 @@ function(jucer_project_end)
       unset(Standalone_sources)
       unset(SharedCode_sources)
       foreach(src_file ${JUCER_PROJECT_SOURCES})
-        # See XCodeProjectExporter::getTargetTypeFromFilePath()
-        # in JUCE/extras/Projucer/Source/Project Saving/jucer_ProjectExport_XCode.h
+        # See Project::getTargetTypeFromFilePath()
+        # in JUCE/extras/Projucer/Source/Project/jucer_Project.cpp
         if(src_file MATCHES "_AU[._]")
           list(APPEND AudioUnit_sources "${src_file}")
         elseif(src_file MATCHES "_AUv3[._]")
@@ -2063,7 +2063,7 @@ function(_FRUT_generate_AppConfig_header)
     set(is_standalone_application 0)
 
     # See ProjectSaver::writePluginCharacteristicsFile()
-    # in JUCE/extras/Projucer/Source/Project Saving/jucer_ProjectSaver.cpp
+    # in JUCE/extras/Projucer/Source/ProjectSaving/jucer_ProjectSaver.cpp
 
     set(audio_plugin_setting_names
       "Build_VST" "Build_VST3" "Build_AU" "Build_AUv3" "Build_RTAS" "Build_AAX"
@@ -2173,7 +2173,7 @@ function(_FRUT_generate_AppConfig_header)
     string(LENGTH "${JUCER_PLUGIN_CHANNEL_CONFIGURATIONS}" plugin_channel_config_length)
     if(plugin_channel_config_length GREATER 0)
       # See countMaxPluginChannels()
-      # in JUCE/extras/Projucer/Source/Project Saving/jucer_ProjectSaver.cpp
+      # in JUCE/extras/Projucer/Source/ProjectSaving/jucer_ProjectSaver.cpp
       string(REGEX REPLACE "[, {}]" ";" configs "${JUCER_PLUGIN_CHANNEL_CONFIGURATIONS}")
       set(max_num_input 0)
       set(max_num_output 0)

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1739,13 +1739,14 @@ function(jucer_project_end)
         unset(auv3_target)
       endif()
 
-      if(JUCER_BUILD_AUDIOUNIT_V3
-          AND DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
-        set(juce4_standalone ON)
+      if(DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
+        if(JUCER_BUILD_AUDIOUNIT_V3)
+          set(juce4_standalone ON)
+        endif()
+      elseif(JUCER_BUILD_STANDALONE_PLUGIN)
+        set(juce5_standalone ON)
       endif()
-
-      if(juce4_standalone OR (JUCER_BUILD_STANDALONE_PLUGIN
-          AND NOT (DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)))
+      if(juce4_standalone OR juce5_standalone)
         if(juce4_standalone)
           set(standalone_target ${target}_AUv3_Standalone)
         else()

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -202,14 +202,13 @@ function(jucer_audio_plugin_settings)
     )
   endif()
 
-  if(DEFINED _BUILD_STANDALONE_PLUGIN
-      AND DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
-    message(WARNING "BUILD_STANDALONE_PLUGIN is a JUCE 5 feature only")
-  endif()
-
-  if(DEFINED _ENABLE_INTERAPP_AUDIO
-      AND DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
-    message(WARNING "ENABLE_INTERAPP_AUDIO is a JUCE 5 feature only")
+  if(DEFINED JUCER_VERSION AND JUCER_VERSION VERSION_LESS 5.0.0)
+    if(DEFINED _BUILD_STANDALONE_PLUGIN)
+      message(WARNING "BUILD_STANDALONE_PLUGIN is a JUCE 5 feature only")
+    endif()
+    if(DEFINED _ENABLE_INTERAPP_AUDIO)
+      message(WARNING "ENABLE_INTERAPP_AUDIO is a JUCE 5 feature only")
+    endif()
   endif()
 
   foreach(keyword ${single_value_keywords})


### PR DESCRIPTION
#353 actually added support for building AAX plugins with JUCE 5 only. This PR fixes this limitation by using the same logic for both JUCE 4 and JUCE 5.

@MartyLake: please review, thanks!