### PR TITLE
Fallback to the first configuration when CMAKE_BUILD_TYPE is empty

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1284,7 +1284,7 @@ function(jucer_project_end)
   endif()
 
   if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
-    if(NOT DEFINED CMAKE_BUILD_TYPE)
+    if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
       list(GET JUCER_PROJECT_CONFIGURATIONS 0 first_configuration)
       message(STATUS
         "Setting CMAKE_BUILD_TYPE to \"${first_configuration}\" as it was not specified."


### PR DESCRIPTION
This behavior was broken in https://github.com/McMartin/FRUT/pull/374.

@MartyLake: please review, thanks!