### PR TITLE
Fix support compiling .r resources files for AU plugins with MacOS 10.14

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1785,6 +1785,7 @@ function(jucer_project_end)
             "-o" "${rez_output}"
             "-d" "SystemSevenOrLater=1"
             "-useDF"
+            "-isysroot" "${CMAKE_OSX_SYSROOT}"
             ${rez_defines}
             ${rez_archs}
             "-i" "${carbon_include_dir}"


### PR DESCRIPTION
Additional fix for #400.

On MacOS 10.14, Apple Frameworks located in `/System/Library/Frameworks` seem to be "broken" and/or incomplete. Specifically, the `AudioUnit.framework` is missing all the headers required to compile .r resources for AU plugins (e.g. `<AudioUnit/AudioUnit.r>`).

Using the XCode SDKs by specifying the `-isysroot` argument to `Rez` fixes the issue.