### PR TITLE
Fix broken links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,7 @@ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
 .. _generated/JUCE-4.3.1: generated/JUCE-4.3.1
 .. _generated/JUCE-5.0.0: generated/JUCE-5.0.0
 .. _generated/JUCE-5.2.1: generated/JUCE-5.2.1
+.. _generated/JUCE-5.3.1: generated/JUCE-5.3.1
 
 .. _CMake Generators: https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
 .. _CMake: https://cmake.org/
@@ -162,4 +163,5 @@ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
 .. _JUCE 4.3.1: https://github.com/WeAreROLI/JUCE/tree/4.3.1
 .. _JUCE 5.0.0: https://github.com/WeAreROLI/JUCE/tree/5.0.0
 .. _JUCE 5.2.1: https://github.com/WeAreROLI/JUCE/tree/5.2.1
+.. _JUCE 5.3.1: https://github.com/WeAreROLI/JUCE/tree/5.3.1
 .. _Projucer: https://www.juce.com/projucer


### PR DESCRIPTION
This should have been done in https://github.com/McMartin/FRUT/pull/389.

@MartyLake: FYI