### PR TITLE
Include JUCER_ prefix in variable reference

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -3967,7 +3967,7 @@ function(_FRUT_set_cxx_language_standard_properties target)
       endif()
 
     else()
-      if(GNU_COMPILER_EXTENSIONS)
+      if(JUCER_GNU_COMPILER_EXTENSIONS)
         set_target_properties(${target} PROPERTIES CXX_EXTENSIONS ON)
       else()
         set_target_properties(${target} PROPERTIES CXX_EXTENSIONS OFF)


### PR DESCRIPTION
That is in fact the variable name as it's used elsewhere in the function.