### PR TITLE
Specify how to generate the output file

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -2031,7 +2031,7 @@ function(jucer_project_end)
             "juce_audio_plugin_client"
           )
 
-          add_custom_command(TARGET ${au_target} PRE_BUILD
+          add_custom_command(OUTPUT ${rez_output}
             COMMAND
             "${Rez_tool}"
             "-o" "${rez_output}"


### PR DESCRIPTION
I'm not sure if there was a specific reason that this was attached to the target rather than providing instructions to CMake as to how to build this file, but the current code is broken for the Ninja generator (which I mostly use), and this change makes it work for all of the relevant (Ninja, make, XCode) generators.