### PR TITLE
Fix non-Xcode macOS version targeting

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -3618,7 +3618,7 @@ function(_FRUT_set_compiler_and_linker_settings target)
           OUTPUT_STRIP_TRAILING_WHITESPACE
         )
         if(IS_DIRECTORY "${sysroot}")
-          target_compile_options(${target} PRIVATE "-isysroot ${sysroot}")
+          target_compile_options(${target} PRIVATE -isysroot "${sysroot}")
         else()
           message(WARNING "Running `xcrun --sdk macosx${sdkroot} --show-sdk-path` didn't"
             " output a valid directory."

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -3609,6 +3609,9 @@ function(_FRUT_set_compiler_and_linker_settings target)
       target_compile_options(${target} PRIVATE
         "-mmacosx-version-min=${osx_deployment_target}"
       )
+      set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS
+        " -mmacosx-version-min=${osx_deployment_target}"
+      )
 
       set(sdkroot "${JUCER_OSX_BASE_SDK_VERSION_${CMAKE_BUILD_TYPE}}")
       if(sdkroot)
@@ -3619,6 +3622,9 @@ function(_FRUT_set_compiler_and_linker_settings target)
         )
         if(IS_DIRECTORY "${sysroot}")
           target_compile_options(${target} PRIVATE -isysroot "${sysroot}")
+          set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS
+            " -isysroot ${sysroot}"
+          )
         else()
           message(WARNING "Running `xcrun --sdk macosx${sdkroot} --show-sdk-path` didn't"
             " output a valid directory."


### PR DESCRIPTION
Currently neither `OSX_DEPLOYMENT_TARGET` nor `OSX_BASE_SDK_VERSION` work for non-Xcode builds.  This fixes two issues to get things working for both of them.  This can be verified with the trivial script:

```
#!/bin/bash

otool -l $1 | grep -A4 LC_VERSION_MIN_MACOSX | head -4
```