### PR TITLE
Install AAX to home Library

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -2173,7 +2173,7 @@ function(jucer_project_end)
         endforeach()
 
         _FRUT_install_to_plugin_binary_location(${aax_target} "AAX"
-          "/Library/Application Support/Avid/Audio/Plug-Ins"
+          "$ENV{HOME}/Library/Application Support/Avid/Audio/Plug-Ins"
         )
       elseif(MSVC)
         set_property(TARGET ${aax_target} PROPERTY SUFFIX ".aaxdll")


### PR DESCRIPTION
Other plugin types' installation steps install to the user's `Library` directory. AAX installation isn't behaving like other plugin formats. It isn't until reading back through the logs that I realized that its installing to a different location from those formats. The first time you run a build after adding AAX support results in its inability to write to `/Library` due to permissions issues.

Plugin development seems fraught with strange behaviors so if this is an erroneous PR, let me know. It could be that this was done on purpose—that the user's `Library` will not load properly in ProTools. If this is the case, please shut this PR down.