### PR TITLE
Change juce::ScopedPointer to std::unique_ptr

### DIFF
--- a/cmake/BinaryDataBuilder/extras/Projucer/Source/Utility/jucer_FileHelpers.cpp
+++ b/cmake/BinaryDataBuilder/extras/Projucer/Source/Utility/jucer_FileHelpers.cpp
@@ -47,6 +47,7 @@
 
 #include "../jucer_Headers.h"
 
+#include <memory>
 
 //==============================================================================
 namespace FileHelpers
@@ -85,7 +86,7 @@ namespace FileHelpers
 
     int64 calculateFileHashCode (const File& file)
     {
-        ScopedPointer<FileInputStream> stream (file.createInputStream());
+        std::unique_ptr<FileInputStream> stream{file.createInputStream()};
         return stream != nullptr ? calculateStreamHashCode (*stream) : 0;
     }
 

--- a/cmake/IconBuilder/Source/Project Saving/jucer_ProjectExporter.cpp
+++ b/cmake/IconBuilder/Source/Project Saving/jucer_ProjectExporter.cpp
@@ -48,26 +48,28 @@
 #include "../jucer_Headers.h"
 #include "jucer_ProjectExporter.h"
 
+#include <memory>
+
 
 Image ProjectExporter::getBestIconForSize (int size, bool returnNullIfNothingBigEnough) const
 {
     Drawable* im = nullptr;
 
-    ScopedPointer<Drawable> im1 (getSmallIcon());
-    ScopedPointer<Drawable> im2 (getBigIcon());
+    std::unique_ptr<Drawable> im1 (getSmallIcon());
+    std::unique_ptr<Drawable> im2 (getBigIcon());
 
     if (im1 != nullptr && im2 != nullptr)
     {
         if (im1->getWidth() >= size && im2->getWidth() >= size)
-            im = im1->getWidth() < im2->getWidth() ? im1 : im2;
+            im = im1->getWidth() < im2->getWidth() ? im1.get() : im2.get();
         else if (im1->getWidth() >= size)
-            im = im1;
+            im = im1.get();
         else if (im2->getWidth() >= size)
-            im = im2;
+            im = im2.get();
     }
     else
     {
-        im = im1 != nullptr ? im1 : im2;
+        im = im1 != nullptr ? im1.get() : im2.get();
     }
 
     if (im == nullptr)

--- a/cmake/IconBuilder/Source/Project Saving/jucer_ProjectExporter.h
+++ b/cmake/IconBuilder/Source/Project Saving/jucer_ProjectExporter.h
@@ -19,6 +19,7 @@
 
 #include "../jucer_Headers.h"
 
+#include <memory>
 
 class ProjectExporter
 {
@@ -30,12 +31,12 @@ public:
   {
   }
 
-  Drawable* getBigIcon() const
+  std::unique_ptr<Drawable> getBigIcon() const
   {
     return Drawable::createFromImageFile(mBigIcon);
   }
 
-  Drawable* getSmallIcon() const
+  std::unique_ptr<Drawable> getSmallIcon() const
   {
     return Drawable::createFromImageFile(mSmallIcon);
   }

--- a/cmake/IconBuilder/main.cpp
+++ b/cmake/IconBuilder/main.cpp
@@ -21,6 +21,7 @@
 #include "Source/Utility/jucer_FileHelpers.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -52,13 +53,13 @@ int main(int argc, char* argv[])
   {
     OwnedArray<Drawable> images;
 
-    ScopedPointer<Drawable> bigIcon{projectExporter.getBigIcon()};
+    std::unique_ptr<Drawable> bigIcon{projectExporter.getBigIcon()};
     if (bigIcon)
     {
       images.add(bigIcon.release());
     }
 
-    ScopedPointer<Drawable> smallIcon{projectExporter.getSmallIcon()};
+    std::unique_ptr<Drawable> smallIcon{projectExporter.getSmallIcon()};
     if (smallIcon)
     {
       images.add(smallIcon.release());

--- a/cmake/PListMerger/main.cpp
+++ b/cmake/PListMerger/main.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,7 @@ int main(int argc, char* argv[])
 
   const std::vector<std::string> args{argv, argv + argc};
 
-  const juce::ScopedPointer<juce::XmlElement> firstPlistElement =
+  const std::unique_ptr<juce::XmlElement> firstPlistElement =
     juce::XmlDocument::parse(args.at(1));
   if (!firstPlistElement || !firstPlistElement->hasTagName("plist"))
   {
@@ -85,7 +86,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  const juce::ScopedPointer<juce::XmlElement> secondPlistElement =
+  const std::unique_ptr<juce::XmlElement> secondPlistElement =
     juce::XmlDocument::parse(args.at(2));
   if (!secondPlistElement || !secondPlistElement->hasTagName("plist"))
   {


### PR DESCRIPTION
Change the use of juce::ScopedPointer to std::unique_ptr in order to adapt to the API change introduced in JUCE 5.4.4.