### PR TITLE
Add configuration name sanitization to Jucer2Reproducer

### DIFF
--- a/Jucer2Reprojucer/CMakeLists.txt
+++ b/Jucer2Reprojucer/CMakeLists.txt
@@ -103,7 +103,7 @@ jucer_project_module(
 
 jucer_export_target(
   "Xcode (MacOSX)"
-  COMPILER_FLAGS_FOR_maximum_warnings "-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded"
+  COMPILER_FLAGS_FOR_maximum_warnings "-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-exit-time-destructors -Wno-padded"
 )
 
 jucer_export_target_configuration(

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -2006,9 +2006,19 @@ int main(int argc, char* argv[])
       {
         const auto configuration = configurations.getChild(i);
 
+        const auto originalConfigName = configuration.getProperty("name").toString();
+        const auto sanitizedConfigName = sanitizeConfigurationName(originalConfigName);
+
         wLn("jucer_export_target_configuration(");
         wLn("  \"", exporterName, "\"");
-        wLn("  NAME \"", configuration.getProperty("name").toString(), "\"");
+        if (originalConfigName != sanitizedConfigName)
+        {
+          const auto jucerFileBasename = jucerFile.getFileName();
+          wLn("  NAME \"", sanitizedConfigName, "\" # \"", originalConfigName, "\" in ",
+              jucerFileBasename);
+        }
+        else
+          wLn("  NAME \"", sanitizedConfigName, "\"");
 
         const auto isDebug = bool{configuration.getProperty("isDebug")};
         wLn("  DEBUG_MODE ", (isDebug ? "ON" : "OFF"));

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -691,14 +691,7 @@ int main(int argc, char* argv[])
     wLn();
   }
 
-  auto escapedJucerFileName = jucerFileName.toStdString();
-  std::replace_if(
-    escapedJucerFileName.begin(), escapedJucerFileName.end(),
-    [](const std::string::value_type& c) {
-      return !(std::isalpha(c, std::locale::classic())
-               || std::isdigit(c, std::locale::classic()));
-    },
-    '_');
+  auto escapedJucerFileName = sanitizeName(jucerFileName);
   const auto jucerFileCMakeVar = juce::String{escapedJucerFileName} + "_FILE";
 
   // get_filename_component() or set(*_FILE)


### PR DESCRIPTION
`Jucer2Reproducer` now removes invalid characters from configuration names and ensures that they are unique to each exporter by adding digits if required. If the name was changed, a warning is printed to cerr.
