### PR TITLE
Handle configuration names that are not valid for CMake in Reprojucer.cmake

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1114,8 +1114,10 @@ function(jucer_export_target_configuration
   endif()
 
   if(NOT config MATCHES "^[A-Za-z0-9_]+$")
+    _FRUT_make_valid_configuration_name("${config}" valid_config)
     message(FATAL_ERROR "\"${config}\" is not a valid CMake build configuration name."
-      " Configuration names must match \"^[A-Za-z0-9_]+$\"."
+      " Configuration names must match \"^[A-Za-z0-9_]+$\". You can use"
+      " \"${valid_config}\" instead."
     )
   endif()
 
@@ -2505,6 +2507,16 @@ function(_FRUT_abs_path_based_on_jucer_project_dir out_path in_path)
 
   get_filename_component(in_path "${in_path}" ABSOLUTE BASE_DIR "${JUCER_PROJECT_DIR}")
   set(${out_path} "${in_path}" PARENT_SCOPE)
+
+endfunction()
+
+
+function(_FRUT_make_valid_configuration_name config out_var)
+
+  string(REGEX REPLACE "[^A-Za-z0-9_]" " " config "${config}")
+  string(STRIP "${config}" config)
+  string(REGEX REPLACE "[ ]+" "_" config "${config}")
+  set(${out_var} "${config}" PARENT_SCOPE)
 
 endfunction()
 

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1113,6 +1113,12 @@ function(jucer_export_target_configuration
     )
   endif()
 
+  if(NOT config MATCHES "^[A-Za-z0-9_]+$")
+    message(FATAL_ERROR "\"${config}\" is not a valid CMake build configuration name."
+      " Configuration names must match \"^[A-Za-z0-9_]+$\"."
+    )
+  endif()
+
   if(NOT DEBUG_MODE_KEYWORD STREQUAL "DEBUG_MODE")
     message(FATAL_ERROR "Invalid fourth argument. Expected \"DEBUG_MODE\" keyword, "
       "but got \"${DEBUG_MODE_KEYWORD}\" instead."


### PR DESCRIPTION
This is resolving #520 partially. What is left is making Jucer2Reprojucer write valid configuration names when converting `.jucer` files, and is being worked on in #521 by @TheSlowGrowth.

@MartyLake: please review, thanks!