### PR TITLE
Add the "big object files" as options for MinGW

### DIFF
--- a/cmake/IconBuilder/CMakeLists.txt
+++ b/cmake/IconBuilder/CMakeLists.txt
@@ -143,6 +143,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
 endif()
 
 if(WIN32 AND NOT MSVC)
+  target_compile_options(IconBuilder PRIVATE "-Wa,-mbig-obj")
   target_link_libraries(IconBuilder PRIVATE
     -limm32
     -lshlwapi


### PR DESCRIPTION
Pass the `-mbig-obj` option to the assembler, in case of using MinGW on windows, in order to prevent an error regarding too big object files, which is a known error for MinGW. This fixes it!

(As discussed in https://github.com/McMartin/FRUT/issues/513)