### PR TITLE
Avoid error about deprecated i386 architecture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,13 +264,18 @@ contributors:
       <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Arclement" title="Bug reports">🐛</a>
     </td>
     <td>
+      <a href="https://github.com/stijnfrishert"><img src="https://github.com/stijnfrishert.png" width="100"><br />Stijn Frishert</a>
+      <br />
+      <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Astijnfrishert" title="Bug reports">🐛</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
       <a href="https://github.com/czyjerry"><img src="https://github.com/czyjerry.png" width="100"><br />Jerry Chan</a>
       <br />
       <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Aczyjerry" title="Bug reports">🐛</a>
       <a href="https://github.com/McMartin/FRUT/pulls?q=state%3Amerged+reviewed-by%3Aczyjerry+-author%3Aczyjerry+" title="Pull Request reviews">👀</a>
     </td>
-  </tr>
-  <tr>
     <td>
       <a href="https://github.com/franklange"><img src="https://github.com/franklange.png" width="100"><br />Frank Lange</a>
       <br />
@@ -286,8 +291,6 @@ contributors:
       <a href="https://github.com/DustVoice"><img src="https://github.com/DustVoice.png" width="100"><br />David Holland</a>
       <br />
       <a href="https://github.com/McMartin/FRUT/pulls?q=state%3Amerged+author%3ADustVoice" title="Code">💻</a>
-    </td>
-    <td>
     </td>
     <td>
     </td>

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -4488,9 +4488,11 @@ function(_FRUT_set_compiler_and_linker_settings_APPLE target)
           string(APPEND all_confs_archs "$<$<CONFIG:${config}>:${xcode_archs}>")
         endif()
       endforeach()
-      set_target_properties(${target} PROPERTIES
-        XCODE_ATTRIBUTE_ARCHS "${all_confs_archs}"
-      )
+      if(NOT all_confs_archs STREQUAL "")
+        set_target_properties(${target} PROPERTIES
+          XCODE_ATTRIBUTE_ARCHS "${all_confs_archs}"
+        )
+      endif()
     else()
       foreach(config IN LISTS JUCER_PROJECT_CONFIGURATIONS)
         if(DEFINED JUCER_OSX_ARCHITECTURES_${config})


### PR DESCRIPTION
Resolves https://github.com/McMartin/FRUT/issues/473.

@MartyLake: please review, thanks!

@stijnfrishert: I was finally able to reproduce the issue when building the PushNotificationsDemo example project from JUCE 5.2.1 with Xcode 10.1 on macOS 10.13 High Sierra. Sorry for the very long delay.