### PR TITLE
Support building and installing helper executables when cross-compiling

### DIFF
--- a/cmake/BinaryDataBuilder/CMakeLists.txt
+++ b/cmake/BinaryDataBuilder/CMakeLists.txt
@@ -42,6 +42,9 @@ get_filename_component(JUCE_modules_DIR
 )
 
 
+project(BinaryDataBuilder VERSION 0.3.1)
+
+
 if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "Setting CMAKE_BUILD_TYPE to \"Debug\" as it was not specified.")
@@ -49,8 +52,6 @@ if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-
-project(BinaryDataBuilder VERSION 0.3.1)
 
 add_executable(BinaryDataBuilder
   "${CMAKE_CURRENT_LIST_DIR}/main.cpp"

--- a/cmake/BinaryDataBuilder/CMakeLists.txt
+++ b/cmake/BinaryDataBuilder/CMakeLists.txt
@@ -117,8 +117,7 @@ if(WIN32 AND NOT MSVC)
 endif()
 
 
-get_cmake_property(is_in_try_compile IN_TRY_COMPILE)
-if(is_in_try_compile)
+if(built_by_Reprojucer)
   install(TARGETS BinaryDataBuilder DESTINATION ".")
 else()
   install(TARGETS BinaryDataBuilder DESTINATION "FRUT/cmake/bin")

--- a/cmake/IconBuilder/CMakeLists.txt
+++ b/cmake/IconBuilder/CMakeLists.txt
@@ -156,8 +156,7 @@ if(WIN32 AND NOT MSVC)
 endif()
 
 
-get_cmake_property(is_in_try_compile IN_TRY_COMPILE)
-if(is_in_try_compile)
+if(built_by_Reprojucer)
   install(TARGETS IconBuilder DESTINATION ".")
 else()
   install(TARGETS IconBuilder DESTINATION "FRUT/cmake/bin")

--- a/cmake/IconBuilder/CMakeLists.txt
+++ b/cmake/IconBuilder/CMakeLists.txt
@@ -48,6 +48,9 @@ get_filename_component(JUCE_modules_DIR
 )
 
 
+project(IconBuilder VERSION 0.2.0)
+
+
 if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "Setting CMAKE_BUILD_TYPE to \"Debug\" as it was not specified.")
@@ -55,8 +58,6 @@ if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-
-project(IconBuilder VERSION 0.2.0)
 
 add_executable(IconBuilder
   "${CMAKE_CURRENT_LIST_DIR}/main.cpp"

--- a/cmake/PListMerger/CMakeLists.txt
+++ b/cmake/PListMerger/CMakeLists.txt
@@ -112,8 +112,7 @@ if(WIN32 AND NOT MSVC)
 endif()
 
 
-get_cmake_property(is_in_try_compile IN_TRY_COMPILE)
-if(is_in_try_compile)
+if(built_by_Reprojucer)
   install(TARGETS PListMerger DESTINATION ".")
 else()
   install(TARGETS PListMerger DESTINATION "FRUT/cmake/bin")

--- a/cmake/PListMerger/CMakeLists.txt
+++ b/cmake/PListMerger/CMakeLists.txt
@@ -42,6 +42,9 @@ get_filename_component(JUCE_modules_DIR
 )
 
 
+project(PListMerger VERSION 0.1.0)
+
+
 if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "Setting CMAKE_BUILD_TYPE to \"Debug\" as it was not specified.")
@@ -49,8 +52,6 @@ if(NOT DEFINED CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-
-project(PListMerger VERSION 0.1.0)
 
 add_executable(PListMerger
   "${CMAKE_CURRENT_LIST_DIR}/main.cpp"

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -5292,11 +5292,10 @@ function(_FRUT_write_failure_report_and_abort action helper_name execute_process
   configure_file("${Reprojucer_templates_DIR}/failed-to.md"
     "failed-to-${action}-${helper_name}.md" @ONLY
   )
-  message(FATAL_ERROR "Failed to ${action} ${helper_name}. Please report this"
-    " problem by creating a new issue on GitHub:"
-    " https://github.com/McMartin/FRUT/issues/new.\nPlease copy-paste the contents of"
-    " ${CMAKE_CURRENT_BINARY_DIR}/failed-to-${action}-${helper_name}.md in the"
-    " commment."
+  message(FATAL_ERROR "Failed to ${action} ${helper_name}. Please report this problem by"
+    " creating a new issue on GitHub: https://github.com/McMartin/FRUT/issues/new."
+    "\nPlease copy-paste the contents of"
+    " ${CMAKE_CURRENT_BINARY_DIR}/failed-to-${action}-${helper_name}.md in the commment."
   )
 
 endfunction()

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -2834,46 +2834,7 @@ function(_FRUT_build_and_install_helper_exe helper_name helper_version)
       OUTPUT_VARIABLE try_compile_output
     )
     if(NOT ${helper_name})
-      execute_process(
-        COMMAND "git" "rev-parse" "HEAD"
-        WORKING_DIRECTORY "${Reprojucer.cmake_DIR}"
-        OUTPUT_VARIABLE git_rev_parse_output
-        RESULT_VARIABLE git_rev_parse_return_code
-      )
-      if(git_rev_parse_return_code EQUAL 0)
-        string(STRIP "${git_rev_parse_output}" git_rev_parse_output)
-        set(frut_version "commit ${git_rev_parse_output}")
-      else()
-        set(frut_version "unknown (`git rev-parse HEAD` failed)")
-      endif()
-
-      if(DEFINED JUCER_PROJECT_MODULE_juce_core_PATH)
-        execute_process(
-          COMMAND "git" "describe" "--tags" "--always"
-          WORKING_DIRECTORY "${JUCER_PROJECT_MODULE_juce_core_PATH}"
-          OUTPUT_VARIABLE git_describe_output
-          RESULT_VARIABLE git_describe_return_code
-        )
-        if(git_describe_return_code EQUAL 0)
-          string(STRIP "${git_describe_output}" git_describe_output)
-          set(juce_version "`${git_describe_output}`")
-        else()
-          set(juce_version "`${JUCER_PROJECT_MODULE_juce_core_VERSION}`")
-        endif()
-      else()
-        set(juce_version "unknown (no juce_core module)")
-      endif()
-
-      string(REPLACE "\r\n" "\n" try_compile_output "${try_compile_output}")
-      configure_file("${Reprojucer_templates_DIR}/failed-to-build-and-install.md"
-        "failed-to-build-and-install-${helper_name}.md" @ONLY
-      )
-      message(FATAL_ERROR "Failed to build and install ${helper_name}. Please report this"
-        " problem by creating a new issue on GitHub:"
-        " https://github.com/McMartin/FRUT/issues/new.\nPlease copy-paste the contents of"
-        " ${CMAKE_CURRENT_BINARY_DIR}/failed-to-build-and-install-${helper_name}.md in"
-        " the commment."
-      )
+      _FRUT_write_failure_report_and_abort("${helper_name}" "${try_compile_output}")
     endif()
     message(STATUS "Installed ${helper_name} in \"${install_prefix}\"")
     find_program(${helper_name}_exe "${helper_filename}"
@@ -5260,6 +5221,52 @@ function(_FRUT_warn_about_unsupported_setting setting projucer_setting issue_num
     " support this setting, please leave a comment on the issue \"Reprojucer.cmake"
     " doesn't support the setting ${setting}\" on GitHub:"
     " https://github.com/McMartin/FRUT/issues/${issue_number}"
+  )
+
+endfunction()
+
+
+function(_FRUT_write_failure_report_and_abort helper_name try_compile_output)
+
+  execute_process(
+    COMMAND "git" "rev-parse" "HEAD"
+    WORKING_DIRECTORY "${Reprojucer.cmake_DIR}"
+    OUTPUT_VARIABLE git_rev_parse_output
+    RESULT_VARIABLE git_rev_parse_return_code
+  )
+  if(git_rev_parse_return_code EQUAL 0)
+    string(STRIP "${git_rev_parse_output}" git_rev_parse_output)
+    set(frut_version "commit ${git_rev_parse_output}")
+  else()
+    set(frut_version "unknown (`git rev-parse HEAD` failed)")
+  endif()
+
+  if(DEFINED JUCER_PROJECT_MODULE_juce_core_PATH)
+    execute_process(
+      COMMAND "git" "describe" "--tags" "--always"
+      WORKING_DIRECTORY "${JUCER_PROJECT_MODULE_juce_core_PATH}"
+      OUTPUT_VARIABLE git_describe_output
+      RESULT_VARIABLE git_describe_return_code
+    )
+    if(git_describe_return_code EQUAL 0)
+      string(STRIP "${git_describe_output}" git_describe_output)
+      set(juce_version "`${git_describe_output}`")
+    else()
+      set(juce_version "`${JUCER_PROJECT_MODULE_juce_core_VERSION}`")
+    endif()
+  else()
+    set(juce_version "unknown (no juce_core module)")
+  endif()
+
+  string(REPLACE "\r\n" "\n" try_compile_output "${try_compile_output}")
+  configure_file("${Reprojucer_templates_DIR}/failed-to-build-and-install.md"
+    "failed-to-build-and-install-${helper_name}.md" @ONLY
+  )
+  message(FATAL_ERROR "Failed to build and install ${helper_name}. Please report this"
+    " problem by creating a new issue on GitHub:"
+    " https://github.com/McMartin/FRUT/issues/new.\nPlease copy-paste the contents of"
+    " ${CMAKE_CURRENT_BINARY_DIR}/failed-to-build-and-install-${helper_name}.md in the"
+    " commment."
   )
 
 endfunction()

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -2823,9 +2823,11 @@ function(_FRUT_build_and_install_helper_exe helper_name helper_version)
     NO_DEFAULT_PATH
   )
   if(NOT ${helper_name}_exe)
+    set(binary_dir "${Reprojucer.cmake_DIR}/${helper_name}/_build/${CMAKE_GENERATOR}")
+
     message(STATUS "Building and installing ${helper_name}")
     try_compile(${helper_name}
-      "${Reprojucer.cmake_DIR}/${helper_name}/_build/${CMAKE_GENERATOR}"
+      "${binary_dir}"
       "${Reprojucer.cmake_DIR}/${helper_name}"
       ${helper_name} install
       CMAKE_FLAGS

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -2875,7 +2875,7 @@ function(_FRUT_build_and_install_helper_exe helper_name helper_version)
         " the commment."
       )
     endif()
-    message(STATUS "Installed ${helper_name} in ${install_prefix}")
+    message(STATUS "Installed ${helper_name} in \"${install_prefix}\"")
     find_program(${helper_name}_exe "${helper_filename}"
       PATHS "${install_prefix}"
       NO_DEFAULT_PATH

--- a/cmake/templates/failed-to.md
+++ b/cmake/templates/failed-to.md
@@ -1,4 +1,4 @@
-### Failed to build and install `@helper_name@`
+### Failed to @action@ `@helper_name@`
 
 
 #### Versions
@@ -33,8 +33,8 @@ JUCER_VERSION: "@JUCER_VERSION@"
 ```
 
 
-#### Output of `try_compile(@helper_name@)`
+#### Output of `execute_process()`
 
 ```
-@try_compile_output@
+@execute_process_output@
 ```


### PR DESCRIPTION
This is required to support iOS (see https://github.com/McMartin/FRUT/pull/551#issuecomment-551646978).

@MartyLake: please review, thanks!