### PR TITLE
add docker support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,31 @@ Now we can build ``MyGreatProject`` using CMake: ::
 including Ninja, NMake Makefiles (on Windows), Unix Makefiles (on Linux and macOS), Visual
 Studio 2013, 2015 and 2017 (on Windows), and Xcode (on macOS).
 
+Docker
+------
+
+Build
+^^^^^
+To build the Docker image, run ::
+
+  $ cd <root>/FRUT/docker
+  $ docker build -t frut:latest .
+
+This resulting image will contain ``Jucer2Reprojucer`` and ``Reprojucer.cmake`` as well as an ``entrypoint.sh`` for convenince 
+
+Run
+^^^
+To convert a `.jucer` file, run ::
+
+  $ docker run --rm -v <juce_project_directory>:/work frut /work/<juce_project>.jucer
+
+The ``.cmake`` file will be created in the same directory as the ``.jucer`` file. 
+
+Additionally, the Docker image can be entered for manual operation ::
+
+  $ docker run --rm --entrypoint="" -v <juce_project_directory>:/work frut
+
+
 
 Contributing
 ------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1
+FROM debian:stretch-slim AS builder
+
+# install dependencies
+RUN buildDeps='git ca-certificates build-essential cmake xorg-dev libfreetype6-dev pkg-config' \
+    && set -x \
+    && apt-get update && apt-get install -y $buildDeps --no-install-recommends
+
+# build FRUT
+ARG CMAKE_BUILD_TYPE="Release"
+RUN git clone --depth 1 https://github.com/WeAreROLI/JUCE.git \
+    && git clone --depth 1 https://github.com/McMartin/FRUT.git \
+    && mkdir ./FRUT/build && cd ./FRUT/build \
+    && cmake .. -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=./ -DJUCE_ROOT=../../JUCE \
+    && cmake --build . --target install
+
+# Stage 2
+FROM debian:stretch-slim
+
+COPY --from=builder /FRUT/build/FRUT/bin/Jucer2Reprojucer /usr/local/bin
+COPY --from=builder /FRUT/build/FRUT/cmake/Reprojucer.cmake /
+
+COPY entrypoint.sh ./
+RUN chmod +x ./entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+CMD []

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]
+  then
+    echo "usage: provide path and filename for .jucer file"
+    echo "example: /<volumed directoy>/<project name>/<project name>.jucer"
+    echo "note: make sure to volume in your juce project with -v"
+    exit 1
+fi
+DIRECTORY=$(dirname "$1")
+JUCERFILE=$(basename "$1")
+FRUT_CMAKE="/Reprojucer.cmake"
+
+cd ${DIRECTORY}
+Jucer2Reprojucer ${JUCERFILE} ${FRUT_CMAKE}
+
+exit 0 


### PR DESCRIPTION
Adds `Dockerfile` for creating a Docker image which contains the ``Jucer2Reprojucer`` and a helper script (`entrypoint.sh`) for easy integration with command line.

Docker image is based on `debian:stretch-light` and is 57MB in size.

Additionally: updated with instructions for building and running docker image. 