### PR TITLE
Add --parallel to FRUT cmake build command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ We first build and install FRUT with CMake: ::
   -- Generating done
   -- Build files have been written to: <root>/FRUT/build
 
-  $ cmake --build . --target install
+  $ cmake --build . --target install --parallel
   ...
 
 If it fails to build and install, please report the problem by creating a new issue on


### PR DESCRIPTION
For better performance and experience for anyone not familiar with `cmake` (like me).
Would also add it to the build command for the project, but if Xcode is the generator then just `--parallel` doesn't work as is, must specify number of cores, I think. But let's at least accelerate FRUT's build.