### PR TITLE
Add support for imported libraries.

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -745,6 +745,7 @@ function(jucer_export_target exporter)
     "EXTRA_COMPILER_FLAGS"
     "EXTRA_LINKER_FLAGS"
     "EXTERNAL_LIBRARIES_TO_LINK"
+    "IMPORTED_STATIC_LIBRARIES_PATHS"
   )
 
   if(exporter STREQUAL "Xcode (MacOSX)" OR exporter STREQUAL "Xcode (iOS)")
@@ -909,6 +910,10 @@ function(jucer_export_target exporter)
 
   if(DEFINED _EXTRA_LINKER_FLAGS)
     set(JUCER_EXTRA_LINKER_FLAGS "${_EXTRA_LINKER_FLAGS}" PARENT_SCOPE)
+  endif()
+
+  if(DEFINED _IMPORTED_STATIC_LIBRARIES_PATHS)
+      set(IMPORTED_STATIC_LIBRARIES_PATHS "${_IMPORTED_STATIC_LIBRARIES_PATHS}" PARENT_SCOPE)
   endif()
 
   if(DEFINED _EXTERNAL_LIBRARIES_TO_LINK)
@@ -4990,6 +4995,18 @@ function(_FRUT_set_compiler_and_linker_settings target)
     set_property(TARGET ${target} APPEND_STRING PROPERTY LINK_FLAGS " ${flag}")
     set_property(TARGET ${target} APPEND_STRING PROPERTY STATIC_LIBRARY_FLAGS " ${flag}")
   endforeach()
+
+  foreach(lib_path IN LISTS IMPORTED_STATIC_LIBRARIES_PATHS)
+     get_filename_component(lib_file_name "${lib_path}" NAME)
+     # extract library name
+     string(REGEX REPLACE "lib(.+)\.(.+)$" "\\1;" lib_name "${lib_file_name}")
+     message(STATUS "Added imported static library ${lib_name} located at ${lib_path}")
+
+     add_library(${lib_name} STATIC IMPORTED)
+     set_property(TARGET ${lib_name} PROPERTY IMPORTED_LOCATION "${lib_path}")
+     list(APPEND IMPORTED_STATIC_LIBRARIES ${lib_name})
+   endforeach()
+   target_link_libraries(${target} PRIVATE ${IMPORTED_STATIC_LIBRARIES})
 
   target_link_libraries(${target} PRIVATE ${JUCER_EXTERNAL_LIBRARIES_TO_LINK})
 


### PR DESCRIPTION
Hi!
I tried to convert JUCE project which used a list of static libraries that were built separately by other scripts. The resulted CMake file was pretty okay, though I noticed that static libraries end up in EXTRA_LINKER_FLAGS resulting in incorrect CMake linking script (wrong linking order).

This PR adds support for such static libraries. CMake requires to mark these libraries as static imported libraries explicitly and then link them to the target.
I believe this PR solves #517, #525 (though it does not contain appropriate changes in `Jucer2Reprojucer`, which can be added once we finish with `Reprojucer.cmake` changes).

To use it, in exporter settings in FRUT **CMakeLists.txt** add another section with "IMPORTED_STATIC_LIBRARIES_PATHS" header that contains paths to appropriate static libraries:

```
jucer_export_target(
  "Linux Makefile"
  EXTRA_COMPILER_FLAGS
    "-I${CMAKE_CURRENT_SOURCE_DIR}/src"
    "-I${CMAKE_CURRENT_SOURCE_DIR}/src/local_third_party/boost"
  ...
  IMPORTED_STATIC_LIBRARIES_PATHS
    "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/boost/stage/lib/libboost_filesystem.a"
    "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/boost/stage/lib/libboost_iostreams.a"
    "${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/boost/stage/lib/libboost_system.a"
    ...
)
```

I think this will also work for imported dynamic libs, then we can rename the setting to **"IMPORTED_LIBRARIES_PATHS"**, but I don't believe that this is the very popular case (and there are also some workaround ways for it).

As it is my very first time contributing to FRUT, your comments and suggestions are welcome, because something could be not FRUT-way.

Best regards,
Kirill.