### PR TITLE
Fix building projects on macOS that set a non-default BINARY_NAME

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -309,6 +309,9 @@ contributors:
       <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Arorywalsh" title="Bug reports">🐛</a>
     </td>
     <td>
+      <a href="https://github.com/eyalamirmusic"><img src="https://github.com/eyalamirmusic.png" width="100"><br />Eyal Amir</a>
+      <br />
+      <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Aeyalamirmusic" title="Bug reports">🐛</a>
     </td>
     <td>
     </td>

--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -4088,9 +4088,8 @@ function(_FRUT_generate_plist_file
       )
     endif()
   else()
-    set(bundle_executable "\${MACOSX_BUNDLE_BUNDLE_NAME}")
+    set(bundle_executable "\${MACOSX_BUNDLE_EXECUTABLE_NAME}")
     set_target_properties(${target} PROPERTIES
-      MACOSX_BUNDLE_BUNDLE_NAME "${JUCER_PROJECT_NAME}"
       MACOSX_BUNDLE_GUI_IDENTIFIER "${bundle_identifier}"
       MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${plist_filename}"
     )


### PR DESCRIPTION
Resolves #599.

@MartyLake: please review, thanks!
@eyalamirmusic: please confirm that it fixes your problem and that what I wrote on the README is correct, thanks!