### PR TITLE
Yocto Linux - fix for do_package_qa: QA Issue

### DIFF
--- a/cmake/Reprojucer.cmake
+++ b/cmake/Reprojucer.cmake
@@ -1576,6 +1576,7 @@ function(jucer_export_target_configuration
     set(library_search_paths "")
     foreach(path IN LISTS _EXTRA_LIBRARY_SEARCH_PATHS)
       file(TO_CMAKE_PATH "${path}" path)
+      set(path "${CMAKE_SYSROOT}/${path}")
       _FRUT_abs_path_based_on_jucer_project_dir(path "${path}")
       list(APPEND library_search_paths "${path}")
     endforeach()


### PR DESCRIPTION
Address Yocto Linux build error for:

    ERROR: juce-binarybuilder-1.0-r0 do_package_qa: QA Issue: juce-binarybuilder: The compile log indicates that host include and/or library paths were used.

This fix prefixes CMAKE_SYSROOT to _EXTRA_LIBRARY_SEARCH_PATHS values.
When **not** cross-compiling, this variable defaults to empty.

Yocto support for JUCE using FRUT:  [meta-juce](https://github.com/jwinarske/meta-juce)