### PR TITLE
Eliminate juce::ValueTree from Jucer2Reprojucer

### DIFF
--- a/Jucer2Reprojucer/CMakeLists.txt
+++ b/Jucer2Reprojucer/CMakeLists.txt
@@ -86,18 +86,6 @@ jucer_project_module(
   JUCE_USE_CURL OFF
 )
 
-jucer_project_module(
-  juce_data_structures
-  PATH "${JUCE_ROOT}/modules"
-  ADD_SOURCE_TO_PROJECT OFF
-)
-
-jucer_project_module(
-  juce_events
-  PATH "${JUCE_ROOT}/modules"
-  ADD_SOURCE_TO_PROJECT OFF
-)
-
 jucer_export_target(
   "Xcode (MacOSX)"
   COMPILER_FLAGS_FOR_maximum_warnings "-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded"

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -1488,7 +1488,7 @@ int main(int argc, char* argv[])
 
       const auto& exporter = *pExporter;
       const auto exporterVT = juce::ValueTree::fromXml(exporter);
-      const auto exporterType = exporterVT.getType().toString();
+      const auto& exporterType = exporter.getTagName();
 
       if (!supportedExporters.contains(exporterType))
       {

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -750,7 +750,7 @@ int main(int argc, char* argv[])
       const auto tagLine = juce::String{" # Required for closed source applications"
                                         " without an Indie or Pro JUCE license"};
 
-      if (!jucerProjectVT.hasProperty("reportAppUsage"))
+      if (!jucerProject.hasAttribute("reportAppUsage"))
       {
         wLn("  REPORT_JUCE_APP_USAGE ", kDefaultLicenseBasedValue, tagLine);
       }
@@ -762,7 +762,7 @@ int main(int argc, char* argv[])
                             });
       }
 
-      if (!jucerProjectVT.hasProperty("displaySplashScreen"))
+      if (!jucerProject.hasAttribute("displaySplashScreen"))
       {
         wLn("  DISPLAY_THE_JUCE_SPLASH_SCREEN ", kDefaultLicenseBasedValue, tagLine);
       }
@@ -820,7 +820,7 @@ int main(int argc, char* argv[])
                               return juce::File::descriptionOfSizeInBytes(
                                 value.getIntValue());
                             });
-    if (jucerProjectVT.hasProperty("includeBinaryInJuceHeader"))
+    if (jucerProject.hasAttribute("includeBinaryInJuceHeader"))
     {
       convertOnOffSetting(jucerProject, "includeBinaryInJuceHeader", "INCLUDE_BINARYDATA",
                           {});
@@ -833,7 +833,7 @@ int main(int argc, char* argv[])
     convertSettingIfDefined(jucerProject, "binaryDataNamespace", "BINARYDATA_NAMESPACE",
                             {});
 
-    if (jucerProjectVT.hasProperty("cppLanguageStandard"))
+    if (jucerProject.hasAttribute("cppLanguageStandard"))
     {
       convertSetting(jucerProject, "cppLanguageStandard", "CXX_LANGUAGE_STANDARD",
                      [](const juce::String& value) -> juce::String {
@@ -888,7 +888,7 @@ int main(int argc, char* argv[])
 
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        if (!jucerProjectVT.hasProperty("pluginFormats"))
+        if (!jucerProject.hasAttribute("pluginFormats"))
         {
           convertSettingAsList(
             jucerProject, "pluginFormats", "PLUGIN_FORMATS",
@@ -918,7 +918,7 @@ int main(int argc, char* argv[])
             });
         }
 
-        if (!jucerProjectVT.hasProperty("pluginCharacteristicsValue"))
+        if (!jucerProject.hasAttribute("pluginCharacteristicsValue"))
         {
           convertSettingAsList(jucerProject, "pluginCharacteristicsValue",
                                "PLUGIN_CHARACTERISTICS", {});
@@ -1012,7 +1012,7 @@ int main(int argc, char* argv[])
                                 makeValidIdentifier(jucerProjectName) + "AU");
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        if (!jucerProjectVT.hasProperty("pluginAUMainType"))
+        if (!jucerProject.hasAttribute("pluginAUMainType"))
         {
           convertSetting(jucerProject, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
                          [&pluginCharacteristics](const juce::String&) -> juce::String {
@@ -1055,14 +1055,14 @@ int main(int argc, char* argv[])
       convertOnOffSettingIfDefined(jucerProject, "pluginAUIsSandboxSafe",
                                    "PLUGIN_AU_IS_SANDBOX_SAFE", {});
 
-      if (jucerProjectVT.hasProperty("pluginVSTNumMidiInputs")
+      if (jucerProject.hasAttribute("pluginVSTNumMidiInputs")
           || (jucerVersionAsTuple >= Version{5, 4, 2}
               && pluginCharacteristics.contains("pluginWantsMidiIn")))
       {
         convertSettingWithDefault(jucerProject, "pluginVSTNumMidiInputs",
                                   "PLUGIN_VST_NUM_MIDI_INPUTS", "16");
       }
-      if (jucerProjectVT.hasProperty("pluginVSTNumMidiOutputs")
+      if (jucerProject.hasAttribute("pluginVSTNumMidiOutputs")
           || (jucerVersionAsTuple >= Version{5, 4, 2}
               && pluginCharacteristics.contains("pluginProducesMidiOut")))
       {
@@ -1080,10 +1080,10 @@ int main(int argc, char* argv[])
             : "");
       }
 
-      if (jucerProjectVT.hasProperty("pluginVST3Category")
+      if (jucerProject.hasAttribute("pluginVST3Category")
           || jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        if (!jucerProjectVT.hasProperty("pluginVST3Category"))
+        if (!jucerProject.hasAttribute("pluginVST3Category"))
         {
           convertSettingAsList(
             jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
@@ -1113,7 +1113,7 @@ int main(int argc, char* argv[])
 
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        if (!jucerProjectVT.hasProperty("pluginRTASCategory"))
+        if (!jucerProject.hasAttribute("pluginRTASCategory"))
         {
           convertSettingAsList(
             jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
@@ -1146,7 +1146,7 @@ int main(int argc, char* argv[])
             });
         }
 
-        if (!jucerProjectVT.hasProperty("pluginAAXCategory"))
+        if (!jucerProject.hasAttribute("pluginAAXCategory"))
         {
           convertSettingAsList(
             jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
@@ -1506,8 +1506,8 @@ int main(int argc, char* argv[])
         exporterType == "XCODE_MAC" || exporterType == "XCODE_IPHONE";
 
       if (isXcodeExporter
-          && (exporterVT.hasProperty("prebuildCommand")
-              || exporterVT.hasProperty("postbuildCommand")))
+          && (exporter.hasAttribute("prebuildCommand")
+              || exporter.hasAttribute("postbuildCommand")))
       {
         wLn("  TARGET_PROJECT_FOLDER \"", exporter.getStringAttribute("targetFolder"),
             "\"  # only used by PREBUILD_SHELL_SCRIPT and POSTBUILD_SHELL_SCRIPT");
@@ -1977,7 +1977,7 @@ int main(int argc, char* argv[])
       {
         convertSettingIfDefined(exporter, "msvcManifestFile", "MANIFEST_FILE", {});
 
-        if (exporterVT.hasProperty("toolset"))
+        if (exporter.hasAttribute("toolset"))
         {
           const auto& toolset = exporter.getStringAttribute("toolset");
           if (toolset.isEmpty())
@@ -2160,7 +2160,7 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
 
-        if (!configurationVT.hasProperty("linkTimeOptimisation") && isVSExporter && !isDebug
+        if (!configuration.hasAttribute("linkTimeOptimisation") && isVSExporter && !isDebug
             && jucerVersionAsTuple >= Version{5, 2, 0})
         {
           convertOnOffSettingIfDefined(configuration, "wholeProgramOptimisation",
@@ -2252,7 +2252,7 @@ int main(int argc, char* argv[])
 
           if (!vstIsLegacy)
           {
-            if (configurationVT.hasProperty("xcodeVstBinaryLocation"))
+            if (configuration.hasAttribute("xcodeVstBinaryLocation"))
             {
               convertSetting(configuration, "xcodeVstBinaryLocation",
                              "VST_BINARY_LOCATION", {});
@@ -2281,7 +2281,7 @@ int main(int argc, char* argv[])
             const auto& newProperty = std::get<1>(binaryLocationTuple);
             const auto& cmakeKeyword = std::get<2>(binaryLocationTuple);
 
-            if (configurationVT.hasProperty(oldProperty))
+            if (configuration.hasAttribute(oldProperty))
             {
               convertSetting(configuration, oldProperty, cmakeKeyword, {});
             }
@@ -2526,7 +2526,7 @@ int main(int argc, char* argv[])
                                     return value;
                                   });
 
-          if (configurationVT.hasProperty("winArchitecture"))
+          if (configuration.hasAttribute("winArchitecture"))
           {
             const auto& winArchitecture =
               configuration.getStringAttribute("winArchitecture");
@@ -2607,7 +2607,7 @@ int main(int argc, char* argv[])
 
         if (exporterType == "CODEBLOCKS_WINDOWS")
         {
-          if (configurationVT.hasProperty("windowsCodeBlocksArchitecture")
+          if (configuration.hasAttribute("windowsCodeBlocksArchitecture")
               || jucerVersionAsTuple >= Version{5, 0, 0})
           {
             convertSetting(configuration, "windowsCodeBlocksArchitecture", "ARCHITECTURE",
@@ -2617,7 +2617,7 @@ int main(int argc, char* argv[])
 
         if (exporterType == "CODEBLOCKS_LINUX")
         {
-          if (configurationVT.hasProperty("linuxCodeBlocksArchitecture")
+          if (configuration.hasAttribute("linuxCodeBlocksArchitecture")
               || jucerVersionAsTuple >= Version{5, 0, 0})
           {
             convertSetting(configuration, "linuxCodeBlocksArchitecture", "ARCHITECTURE",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -290,12 +290,12 @@ getChildByAttributeRecursively(const juce::XmlElement& parent,
 }
 
 
-void writeUserNotes(LineWriter& wLn, const juce::ValueTree& VT)
+void writeUserNotes(LineWriter& wLn, const juce::XmlElement& element)
 {
-  if (VT.hasProperty("userNotes"))
+  if (element.hasAttribute("userNotes"))
   {
     wLn("  # NOTES");
-    const auto userNotes = VT.getProperty("userNotes").toString();
+    const auto& userNotes = element.getStringAttribute("userNotes");
     for (const auto& line : juce::StringArray::fromLines(userNotes))
     {
       wLn("  #   ", line);
@@ -827,7 +827,7 @@ int main(int argc, char* argv[])
     convertSettingIfDefined(jucerProjectVT, "postExportShellCommandWin",
                             "POST_EXPORT_SHELL_COMMAND_WINDOWS", {});
 
-    writeUserNotes(wLn, jucerProjectVT);
+    writeUserNotes(wLn, jucerProject);
 
     wLn(")");
     wLn();
@@ -2001,7 +2001,7 @@ int main(int argc, char* argv[])
                                 });
       }
 
-      writeUserNotes(wLn, exporterVT);
+      writeUserNotes(wLn, exporter);
 
       wLn(")");
       wLn();
@@ -2571,7 +2571,7 @@ int main(int argc, char* argv[])
           }
         }
 
-        writeUserNotes(wLn, configurationVT);
+        writeUserNotes(wLn, configuration);
 
         wLn(")");
         wLn();

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -859,9 +859,8 @@ int main(int argc, char* argv[])
       wLn("  ", "CXX_LANGUAGE_STANDARD", " \"C++11\"");
     }
 
-    convertSettingAsListIfDefined(
-      jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
-      [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+    convertSettingAsListIfDefined(jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
+                                  parsePreprocessorDefinitions);
     convertSettingAsListIfDefined(
       jucerProject, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::String& value) {
         return juce::StringArray::fromTokens(value, ";\r\n", {});
@@ -1605,9 +1604,9 @@ int main(int argc, char* argv[])
         }
       }
 
-      convertSettingAsListIfDefined(
-        exporter, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
-        [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+      convertSettingAsListIfDefined(exporter, "extraDefs",
+                                    "EXTRA_PREPROCESSOR_DEFINITIONS",
+                                    parsePreprocessorDefinitions);
       convertSettingAsListIfDefined(exporter, "extraCompilerFlags",
                                     "EXTRA_COMPILER_FLAGS",
                                     [](const juce::String& value) {
@@ -2155,9 +2154,9 @@ int main(int argc, char* argv[])
         convertSettingAsListIfDefined(configuration, "libraryPath",
                                       "EXTRA_LIBRARY_SEARCH_PATHS", convertSearchPaths);
 
-        convertSettingAsListIfDefined(
-          configuration, "defines", "PREPROCESSOR_DEFINITIONS",
-          [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+        convertSettingAsListIfDefined(configuration, "defines",
+                                      "PREPROCESSOR_DEFINITIONS",
+                                      parsePreprocessorDefinitions);
 
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
@@ -2379,9 +2378,7 @@ int main(int argc, char* argv[])
 
           convertSettingAsListIfDefined(configuration, "plistPreprocessorDefinitions",
                                         "PLIST_PREPROCESSOR_DEFINITIONS",
-                                        [](const juce::String& value) {
-                                          return parsePreprocessorDefinitions(value);
-                                        });
+                                        parsePreprocessorDefinitions);
 
           convertSettingIfDefined(configuration, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -203,10 +203,9 @@ juce::String escape(const juce::String& charsToEscape, juce::String value)
 
 
 juce::StringArray
-convertIdsToStrings(const juce::var& v,
+convertIdsToStrings(const juce::StringArray& ids,
                     const std::vector<std::pair<juce::String, const char*>>& idsToStrings)
 {
-  const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
   juce::StringArray strings;
   for (const auto& idToString : idsToStrings)
   {
@@ -903,17 +902,19 @@ int main(int argc, char* argv[])
             jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
             [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
               const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
               return convertIdsToStrings(
-                v, {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
-                    {"buildVST3", "VST3"},
-                    {"buildAU", "AU"},
-                    {"buildAUv3", "AUv3"},
-                    {"buildRTAS", "RTAS"},
-                    {"buildAAX", "AAX"},
-                    {"buildStandalone", "Standalone"},
-                    {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
-                    {"enableIAA", "Enable IAA"},
-                    {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
+                ids,
+                {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
+                 {"buildVST3", "VST3"},
+                 {"buildAU", "AU"},
+                 {"buildAUv3", "AUv3"},
+                 {"buildRTAS", "RTAS"},
+                 {"buildAAX", "AAX"},
+                 {"buildStandalone", "Standalone"},
+                 {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
+                 {"enableIAA", "Enable IAA"},
+                 {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
             });
         }
 
@@ -927,16 +928,18 @@ int main(int argc, char* argv[])
           convertSettingAsList(
             jucerProjectVT, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
             [](const juce::var& v) {
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
               return convertIdsToStrings(
-                v, {{"pluginIsSynth", "Plugin is a Synth"},
-                    {"pluginWantsMidiIn", "Plugin MIDI Input"},
-                    {"pluginProducesMidiOut", "Plugin MIDI Output"},
-                    {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
-                    {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
-                    {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
-                    {"pluginAAXDisableBypass", "Disable AAX Bypass"},
-                    {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
-                    {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
+                ids,
+                {{"pluginIsSynth", "Plugin is a Synth"},
+                 {"pluginWantsMidiIn", "Plugin MIDI Input"},
+                 {"pluginProducesMidiOut", "Plugin MIDI Output"},
+                 {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
+                 {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
+                 {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
+                 {"pluginAAXDisableBypass", "Disable AAX Bypass"},
+                 {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
+                 {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
             });
         }
       }
@@ -1125,21 +1128,22 @@ int main(int argc, char* argv[])
           convertSettingAsList(
             jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
             [](const juce::var& v) {
-              return convertIdsToStrings(v, {{"0", "ePlugInCategory_None"},
-                                             {"1", "ePlugInCategory_EQ"},
-                                             {"2", "ePlugInCategory_Dynamics"},
-                                             {"4", "ePlugInCategory_PitchShift"},
-                                             {"8", "ePlugInCategory_Reverb"},
-                                             {"16", "ePlugInCategory_Delay"},
-                                             {"32", "ePlugInCategory_Modulation"},
-                                             {"64", "ePlugInCategory_Harmonic"},
-                                             {"128", "ePlugInCategory_NoiseReduction"},
-                                             {"256", "ePlugInCategory_Dither"},
-                                             {"512", "ePlugInCategory_SoundField"},
-                                             {"1024", "ePlugInCategory_HWGenerators"},
-                                             {"2048", "ePlugInCategory_SWGenerators"},
-                                             {"4096", "ePlugInCategory_WrappedPlugin"},
-                                             {"8192", "ePlugInCategory_Effect"}});
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+              return convertIdsToStrings(ids, {{"0", "ePlugInCategory_None"},
+                                               {"1", "ePlugInCategory_EQ"},
+                                               {"2", "ePlugInCategory_Dynamics"},
+                                               {"4", "ePlugInCategory_PitchShift"},
+                                               {"8", "ePlugInCategory_Reverb"},
+                                               {"16", "ePlugInCategory_Delay"},
+                                               {"32", "ePlugInCategory_Modulation"},
+                                               {"64", "ePlugInCategory_Harmonic"},
+                                               {"128", "ePlugInCategory_NoiseReduction"},
+                                               {"256", "ePlugInCategory_Dither"},
+                                               {"512", "ePlugInCategory_SoundField"},
+                                               {"1024", "ePlugInCategory_HWGenerators"},
+                                               {"2048", "ePlugInCategory_SWGenerators"},
+                                               {"4096", "ePlugInCategory_WrappedPlugin"},
+                                               {"8192", "ePlugInCategory_Effect"}});
             });
         }
 
@@ -1158,21 +1162,22 @@ int main(int argc, char* argv[])
           convertSettingAsList(
             jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
             [](const juce::var& v) -> juce::StringArray {
-              return convertIdsToStrings(v, {{"0", "AAX_ePlugInCategory_None"},
-                                             {"1", "AAX_ePlugInCategory_EQ"},
-                                             {"2", "AAX_ePlugInCategory_Dynamics"},
-                                             {"4", "AAX_ePlugInCategory_PitchShift"},
-                                             {"8", "AAX_ePlugInCategory_Reverb"},
-                                             {"16", "AAX_ePlugInCategory_Delay"},
-                                             {"32", "AAX_ePlugInCategory_Modulation"},
-                                             {"64", "AAX_ePlugInCategory_Harmonic"},
-                                             {"128", "AAX_ePlugInCategory_NoiseReduction"},
-                                             {"256", "AAX_ePlugInCategory_Dither"},
-                                             {"512", "AAX_ePlugInCategory_SoundField"},
-                                             {"1024", "AAX_ePlugInCategory_HWGenerators"},
-                                             {"2048", "AAX_ePlugInCategory_SWGenerators"},
-                                             {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
-                                             {"8192", "AAX_EPlugInCategory_Effect"}});
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+              return convertIdsToStrings(ids, {{"0", "AAX_ePlugInCategory_None"},
+                                               {"1", "AAX_ePlugInCategory_EQ"},
+                                               {"2", "AAX_ePlugInCategory_Dynamics"},
+                                               {"4", "AAX_ePlugInCategory_PitchShift"},
+                                               {"8", "AAX_ePlugInCategory_Reverb"},
+                                               {"16", "AAX_ePlugInCategory_Delay"},
+                                               {"32", "AAX_ePlugInCategory_Modulation"},
+                                               {"64", "AAX_ePlugInCategory_Harmonic"},
+                                               {"128", "AAX_ePlugInCategory_NoiseReduction"},
+                                               {"256", "AAX_ePlugInCategory_Dither"},
+                                               {"512", "AAX_ePlugInCategory_SoundField"},
+                                               {"1024", "AAX_ePlugInCategory_HWGenerators"},
+                                               {"2048", "AAX_ePlugInCategory_SWGenerators"},
+                                               {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
+                                               {"8192", "AAX_EPlugInCategory_Effect"}});
             });
         }
       }
@@ -1744,8 +1749,9 @@ int main(int argc, char* argv[])
                                      "APP_SANDBOX_INHERITANCE", {});
         convertSettingAsListIfDefined(
           exporterVT, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::var& v) {
+            const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
             return convertIdsToStrings(
-              v,
+              ids,
               {{"com.apple.security.network.server",
                 "Network: Incoming Connections (Server)"},
                {"com.apple.security.network.client",
@@ -1811,8 +1817,9 @@ int main(int argc, char* argv[])
           convertSettingAsListIfDefined(
             exporterVT, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
             [](const juce::var& v) {
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
               return convertIdsToStrings(
-                v,
+                ids,
                 {{"com.apple.security.cs.allow-jit",
                   "Runtime Exceptions: Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",
@@ -1844,8 +1851,9 @@ int main(int argc, char* argv[])
           convertSettingAsListIfDefined(
             exporterVT, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
             [](const juce::var& v) {
+              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
               return convertIdsToStrings(
-                v,
+                ids,
                 {{"com.apple.security.cs.allow-jit",
                   "Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -409,7 +409,6 @@ int main(int argc, char* argv[])
   };
 
   const auto& jucerProject = *xml;
-  const auto jucerProjectVT = juce::ValueTree::fromXml(jucerProject);
 
   const auto& jucerVersion = jucerProject.getStringAttribute("jucerVersion");
   const auto jucerVersionTokens = juce::StringArray::fromTokens(jucerVersion, ".", {});
@@ -1323,7 +1322,6 @@ int main(int argc, char* argv[])
       }
       return fallbackXmlElement;
     }();
-    const auto modulePathsVT = juce::ValueTree::fromXml(modulePaths);
 
     const auto& modules = safeGetChildByName(jucerProject, "MODULES");
     for (auto pModule = modules.getFirstChildElement(); pModule != nullptr;
@@ -1335,7 +1333,6 @@ int main(int argc, char* argv[])
       }
 
       const auto& module = *pModule;
-      const auto moduleVT = juce::ValueTree::fromXml(module);
       const auto& moduleName = module.getStringAttribute("id");
 
       const auto useGlobalPath = toBoolLikeVar(module.getStringAttribute("useGlobalPath"));
@@ -1487,7 +1484,6 @@ int main(int argc, char* argv[])
       }
 
       const auto& exporter = *pExporter;
-      const auto exporterVT = juce::ValueTree::fromXml(exporter);
       const auto& exporterType = exporter.getTagName();
 
       if (!supportedExporters.contains(exporterType))
@@ -1497,7 +1493,6 @@ int main(int argc, char* argv[])
 
       const auto exporterName = exporterNames.at(exporterType);
       const auto& configurations = safeGetChildByName(exporter, "CONFIGURATIONS");
-      const auto configurationsVT =juce::ValueTree::fromXml(configurations);
 
       wLn("jucer_export_target(");
       wLn("  \"", exporterName, "\"");
@@ -2091,7 +2086,6 @@ int main(int argc, char* argv[])
         }
 
         const auto& configuration = *pConfiguration;
-        const auto configurationVT = juce::ValueTree::fromXml(configuration);
 
         wLn("jucer_export_target_configuration(");
         wLn("  \"", exporterName, "\"");

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -498,10 +498,16 @@ int main(int argc, char* argv[])
     [&convertSetting](const juce::ValueTree& VT, const juce::Identifier& property,
                       const juce::String& cmakeKeyword,
                       const juce::String& defaultValue) {
-      convertSetting(VT, property, cmakeKeyword,
-                     [&defaultValue](const juce::var& v) -> juce::String {
-                       return v.isVoid() ? defaultValue : v.toString();
-                     });
+      if (!VT.hasProperty(property))
+      {
+        convertSetting(VT, property, cmakeKeyword,
+                       [&defaultValue](const juce::var&) { return defaultValue; });
+      }
+      else
+      {
+        convertSetting(VT, property, cmakeKeyword,
+                       [](const juce::var& v) { return v.toString(); });
+      }
     };
 
   const auto convertOnOffSetting =
@@ -510,9 +516,16 @@ int main(int argc, char* argv[])
            std::function<juce::String(const juce::var&)> converterFn) {
       if (!converterFn)
       {
-        converterFn = [](const juce::var& v) -> juce::String {
-          return v.isVoid() ? "" : bool{v} ? "ON" : "OFF";
-        };
+        if (!VT.hasProperty(property))
+        {
+          converterFn = [](const juce::var&) -> juce::String { return {}; };
+        }
+        else
+        {
+          converterFn = [](const juce::var& v) -> juce::String {
+            return bool{v} ? "ON" : "OFF";
+          };
+        }
       }
 
       const auto value = converterFn(VT.getProperty(property));
@@ -542,11 +555,19 @@ int main(int argc, char* argv[])
     [&convertOnOffSetting](const juce::ValueTree& VT,
                            const juce::Identifier& property,
                            const juce::String& cmakeKeyword, bool defaultValue) {
-      convertOnOffSetting(VT, property, cmakeKeyword,
-                          [defaultValue](const juce::var& v) -> juce::String {
-                            return v.isVoid() ? (defaultValue ? "ON" : "OFF")
-                                              : (bool{v} ? "ON" : "OFF");
-                          });
+      if (!VT.hasProperty(property))
+      {
+        convertOnOffSetting(VT, property, cmakeKeyword,
+                            [defaultValue](const juce::var&) -> juce::String {
+                              return defaultValue ? "ON" : "OFF";
+                            });
+      }
+      else
+      {
+        convertOnOffSetting(
+          VT, property, cmakeKeyword,
+          [](const juce::var& v) -> juce::String { return bool{v} ? "ON" : "OFF"; });
+      }
     };
 
   const auto convertSettingAsList =
@@ -715,18 +736,34 @@ int main(int argc, char* argv[])
 
     if (jucerVersionAsTuple >= Version{5, 0, 0})
     {
-      const auto booleanWithLicenseRequiredTagline = [](const juce::var& v) {
-        const auto value =
-          v.isVoid() ? kDefaultLicenseBasedValue : (bool{v} ? "ON" : "OFF");
-        return juce::String{value}
-               + " # Required for closed source applications without an Indie or Pro "
-                 "JUCE license";
-      };
-      convertOnOffSetting(jucerProjectVT, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
-                          booleanWithLicenseRequiredTagline);
-      convertOnOffSetting(jucerProjectVT, "displaySplashScreen",
-                          "DISPLAY_THE_JUCE_SPLASH_SCREEN",
-                          booleanWithLicenseRequiredTagline);
+      const auto tagLine = juce::String{" # Required for closed source applications"
+                                        " without an Indie or Pro JUCE license"};
+
+      if (!jucerProjectVT.hasProperty("reportAppUsage"))
+      {
+        wLn("  REPORT_JUCE_APP_USAGE ", kDefaultLicenseBasedValue, tagLine);
+      }
+      else
+      {
+        convertOnOffSetting(jucerProjectVT, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
+                            [&tagLine](const juce::var& v) {
+                              return (bool{v} ? "ON" : "OFF") + tagLine;
+                            });
+      }
+
+      if (!jucerProjectVT.hasProperty("displaySplashScreen"))
+      {
+        wLn("  DISPLAY_THE_JUCE_SPLASH_SCREEN ", kDefaultLicenseBasedValue, tagLine);
+      }
+      else
+      {
+        convertOnOffSetting(jucerProjectVT, "displaySplashScreen",
+                            "DISPLAY_THE_JUCE_SPLASH_SCREEN",
+                            [&tagLine](const juce::var& v) {
+                              return (bool{v} ? "ON" : "OFF") + tagLine;
+                            });
+      }
+
       convertSettingIfDefined(jucerProjectVT, "splashScreenColour", "SPLASH_SCREEN_COLOUR",
                               {});
     }
@@ -841,45 +878,56 @@ int main(int argc, char* argv[])
 
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        convertSettingAsList(
-          jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
-          [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
-            if (v.isVoid())
-            {
+        if (!jucerProjectVT.hasProperty("pluginFormats"))
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
+            [&vstIsLegacy](const juce::var&) {
               return juce::StringArray{vstIsLegacy ? "VST3" : "VST", "AU", "Standalone"};
-            }
-            const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
-            return convertIdsToStrings(
-              v, {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
-                  {"buildVST3", "VST3"},
-                  {"buildAU", "AU"},
-                  {"buildAUv3", "AUv3"},
-                  {"buildRTAS", "RTAS"},
-                  {"buildAAX", "AAX"},
-                  {"buildStandalone", "Standalone"},
-                  {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
-                  {"enableIAA", "Enable IAA"},
-                  {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
-          });
+            });
+        }
+        else
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
+            [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
+              const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
+              return convertIdsToStrings(
+                v, {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
+                    {"buildVST3", "VST3"},
+                    {"buildAU", "AU"},
+                    {"buildAUv3", "AUv3"},
+                    {"buildRTAS", "RTAS"},
+                    {"buildAAX", "AAX"},
+                    {"buildStandalone", "Standalone"},
+                    {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
+                    {"enableIAA", "Enable IAA"},
+                    {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
+            });
+        }
 
-        convertSettingAsList(
-          jucerProjectVT, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
-          [](const juce::var& v) {
-            if (v.isVoid())
-            {
-              return juce::StringArray{};
-            }
-            return convertIdsToStrings(
-              v, {{"pluginIsSynth", "Plugin is a Synth"},
-                  {"pluginWantsMidiIn", "Plugin MIDI Input"},
-                  {"pluginProducesMidiOut", "Plugin MIDI Output"},
-                  {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
-                  {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
-                  {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
-                  {"pluginAAXDisableBypass", "Disable AAX Bypass"},
-                  {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
-                  {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
-          });
+        if (!jucerProjectVT.hasProperty("pluginCharacteristicsValue"))
+        {
+          convertSettingAsList(jucerProjectVT, "pluginCharacteristicsValue",
+                               "PLUGIN_CHARACTERISTICS", {});
+        }
+        else
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
+            [](const juce::var& v) {
+              return convertIdsToStrings(
+                v, {{"pluginIsSynth", "Plugin is a Synth"},
+                    {"pluginWantsMidiIn", "Plugin MIDI Input"},
+                    {"pluginProducesMidiOut", "Plugin MIDI Output"},
+                    {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
+                    {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
+                    {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
+                    {"pluginAAXDisableBypass", "Disable AAX Bypass"},
+                    {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
+                    {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
+            });
+        }
       }
       else
       {
@@ -950,10 +998,10 @@ int main(int argc, char* argv[])
                                 makeValidIdentifier(jucerProjectName) + "AU");
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        convertSetting(jucerProjectVT, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
-                       [&pluginCharacteristics](const juce::var& v) -> juce::String {
-                         if (v.isVoid())
-                         {
+        if (!jucerProjectVT.hasProperty("pluginAUMainType"))
+        {
+          convertSetting(jucerProjectVT, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
+                         [&pluginCharacteristics](const juce::var&) -> juce::String {
                            if (pluginCharacteristics.contains("pluginIsMidiEffectPlugin"))
                              return "kAudioUnitType_MIDIProcessor"; // 'aumi'
 
@@ -964,23 +1012,28 @@ int main(int argc, char* argv[])
                              return "kAudioUnitType_MusicEffect"; // 'aumf'
 
                            return "kAudioUnitType_Effect"; // 'aufx'
-                         }
-
-                         const auto value = v.toString();
-                         // clang-format off
-                         if (value == "'aufx'") return "kAudioUnitType_Effect";
-                         if (value == "'aufc'") return "kAudioUnitType_FormatConverter";
-                         if (value == "'augn'") return "kAudioUnitType_Generator";
-                         if (value == "'aumi'") return "kAudioUnitType_MIDIProcessor";
-                         if (value == "'aumx'") return "kAudioUnitType_Mixer";
-                         if (value == "'aumu'") return "kAudioUnitType_MusicDevice";
-                         if (value == "'aumf'") return "kAudioUnitType_MusicEffect";
-                         if (value == "'auol'") return "kAudioUnitType_OfflineEffect";
-                         if (value == "'auou'") return "kAudioUnitType_Output";
-                         if (value == "'aupn'") return "kAudioUnitType_Panner";
-                         // clang-format on
-                         return value;
-                       });
+                         });
+        }
+        else
+        {
+          convertSetting(jucerProjectVT, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
+                         [](const juce::var& v) -> juce::String {
+                           const auto value = v.toString();
+                           // clang-format off
+                           if (value == "'aufx'") return "kAudioUnitType_Effect";
+                           if (value == "'aufc'") return "kAudioUnitType_FormatConverter";
+                           if (value == "'augn'") return "kAudioUnitType_Generator";
+                           if (value == "'aumi'") return "kAudioUnitType_MIDIProcessor";
+                           if (value == "'aumx'") return "kAudioUnitType_Mixer";
+                           if (value == "'aumu'") return "kAudioUnitType_MusicDevice";
+                           if (value == "'aumf'") return "kAudioUnitType_MusicEffect";
+                           if (value == "'auol'") return "kAudioUnitType_OfflineEffect";
+                           if (value == "'auou'") return "kAudioUnitType_Output";
+                           if (value == "'aupn'") return "kAudioUnitType_Panner";
+                           // clang-format on
+                           return value;
+                         });
+        }
       }
       else
       {
@@ -1017,78 +1070,100 @@ int main(int argc, char* argv[])
       if (jucerProjectVT.hasProperty("pluginVST3Category")
           || jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        convertSettingAsList(
-          jucerProjectVT, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-          [isSynthAudioPlugin](const juce::var& v) {
-            if (v.isVoid())
-            {
+        if (!jucerProjectVT.hasProperty("pluginVST3Category"))
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
+            [isSynthAudioPlugin](const juce::var&) {
               return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
                                         : juce::StringArray{"Fx"};
-            }
-            auto vst3_category = juce::StringArray::fromTokens(v.toString(), ",", {});
-            if (vst3_category.contains("Instrument"))
-            {
-              vst3_category.move(vst3_category.indexOf("Instrument"), 0);
-            }
-            if (vst3_category.contains("Fx"))
-            {
-              vst3_category.move(vst3_category.indexOf("Fx"), 0);
-            }
-            return vst3_category;
-          });
+            });
+        }
+        else
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
+            [](const juce::var& v) {
+              auto vst3_category = juce::StringArray::fromTokens(v.toString(), ",", {});
+              if (vst3_category.contains("Instrument"))
+              {
+                vst3_category.move(vst3_category.indexOf("Instrument"), 0);
+              }
+              if (vst3_category.contains("Fx"))
+              {
+                vst3_category.move(vst3_category.indexOf("Fx"), 0);
+              }
+              return vst3_category;
+            });
+        }
       }
 
       if (jucerVersionAsTuple >= Version{5, 3, 1})
       {
-        convertSettingAsList(
-          jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-          [isSynthAudioPlugin](const juce::var& v) {
-            if (v.isVoid())
-            {
+        if (!jucerProjectVT.hasProperty("pluginRTASCategory"))
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
+            [isSynthAudioPlugin](const juce::var&) {
               return juce::StringArray{isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
                                                           : "ePlugInCategory_None"};
-            }
-            return convertIdsToStrings(v, {{"0", "ePlugInCategory_None"},
-                                           {"1", "ePlugInCategory_EQ"},
-                                           {"2", "ePlugInCategory_Dynamics"},
-                                           {"4", "ePlugInCategory_PitchShift"},
-                                           {"8", "ePlugInCategory_Reverb"},
-                                           {"16", "ePlugInCategory_Delay"},
-                                           {"32", "ePlugInCategory_Modulation"},
-                                           {"64", "ePlugInCategory_Harmonic"},
-                                           {"128", "ePlugInCategory_NoiseReduction"},
-                                           {"256", "ePlugInCategory_Dither"},
-                                           {"512", "ePlugInCategory_SoundField"},
-                                           {"1024", "ePlugInCategory_HWGenerators"},
-                                           {"2048", "ePlugInCategory_SWGenerators"},
-                                           {"4096", "ePlugInCategory_WrappedPlugin"},
-                                           {"8192", "ePlugInCategory_Effect"}});
-          });
-        convertSettingAsList(
-          jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-          [isSynthAudioPlugin](const juce::var& v) -> juce::StringArray {
-            if (v.isVoid())
-            {
+            });
+        }
+        else
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
+            [](const juce::var& v) {
+              return convertIdsToStrings(v, {{"0", "ePlugInCategory_None"},
+                                             {"1", "ePlugInCategory_EQ"},
+                                             {"2", "ePlugInCategory_Dynamics"},
+                                             {"4", "ePlugInCategory_PitchShift"},
+                                             {"8", "ePlugInCategory_Reverb"},
+                                             {"16", "ePlugInCategory_Delay"},
+                                             {"32", "ePlugInCategory_Modulation"},
+                                             {"64", "ePlugInCategory_Harmonic"},
+                                             {"128", "ePlugInCategory_NoiseReduction"},
+                                             {"256", "ePlugInCategory_Dither"},
+                                             {"512", "ePlugInCategory_SoundField"},
+                                             {"1024", "ePlugInCategory_HWGenerators"},
+                                             {"2048", "ePlugInCategory_SWGenerators"},
+                                             {"4096", "ePlugInCategory_WrappedPlugin"},
+                                             {"8192", "ePlugInCategory_Effect"}});
+            });
+        }
+
+        if (!jucerProjectVT.hasProperty("pluginAAXCategory"))
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
+            [isSynthAudioPlugin](const juce::var&) -> juce::StringArray {
               return juce::StringArray{isSynthAudioPlugin
                                          ? "AAX_ePlugInCategory_SWGenerators"
                                          : "AAX_ePlugInCategory_None"};
-            }
-            return convertIdsToStrings(v, {{"0", "AAX_ePlugInCategory_None"},
-                                           {"1", "AAX_ePlugInCategory_EQ"},
-                                           {"2", "AAX_ePlugInCategory_Dynamics"},
-                                           {"4", "AAX_ePlugInCategory_PitchShift"},
-                                           {"8", "AAX_ePlugInCategory_Reverb"},
-                                           {"16", "AAX_ePlugInCategory_Delay"},
-                                           {"32", "AAX_ePlugInCategory_Modulation"},
-                                           {"64", "AAX_ePlugInCategory_Harmonic"},
-                                           {"128", "AAX_ePlugInCategory_NoiseReduction"},
-                                           {"256", "AAX_ePlugInCategory_Dither"},
-                                           {"512", "AAX_ePlugInCategory_SoundField"},
-                                           {"1024", "AAX_ePlugInCategory_HWGenerators"},
-                                           {"2048", "AAX_ePlugInCategory_SWGenerators"},
-                                           {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
-                                           {"8192", "AAX_EPlugInCategory_Effect"}});
-          });
+            });
+        }
+        else
+        {
+          convertSettingAsList(
+            jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
+            [](const juce::var& v) -> juce::StringArray {
+              return convertIdsToStrings(v, {{"0", "AAX_ePlugInCategory_None"},
+                                             {"1", "AAX_ePlugInCategory_EQ"},
+                                             {"2", "AAX_ePlugInCategory_Dynamics"},
+                                             {"4", "AAX_ePlugInCategory_PitchShift"},
+                                             {"8", "AAX_ePlugInCategory_Reverb"},
+                                             {"16", "AAX_ePlugInCategory_Delay"},
+                                             {"32", "AAX_ePlugInCategory_Modulation"},
+                                             {"64", "AAX_ePlugInCategory_Harmonic"},
+                                             {"128", "AAX_ePlugInCategory_NoiseReduction"},
+                                             {"256", "AAX_ePlugInCategory_Dither"},
+                                             {"512", "AAX_ePlugInCategory_SoundField"},
+                                             {"1024", "AAX_ePlugInCategory_HWGenerators"},
+                                             {"2048", "AAX_ePlugInCategory_SWGenerators"},
+                                             {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
+                                             {"8192", "AAX_EPlugInCategory_Effect"}});
+            });
+        }
       }
       else
       {

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -23,7 +23,6 @@
   #pragma clang diagnostic ignored "-Wcast-align"
   #pragma clang diagnostic ignored "-Wcast-qual"
   #pragma clang diagnostic ignored "-Wdocumentation"
-  #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
   #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
   #pragma clang diagnostic ignored "-Wexit-time-destructors"
   #pragma clang diagnostic ignored "-Wextra-semi"

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -983,9 +983,10 @@ int main(int argc, char* argv[])
       const auto pluginCharacteristics = juce::StringArray::fromTokens(
         jucerProject.getStringAttribute("pluginCharacteristicsValue"), ",", {});
 
-      const auto isSynthAudioPlugin = jucerVersionAsTuple >= Version{5, 3, 1}
-                                        ? pluginCharacteristics.contains("pluginIsSynth")
-                                        : toBoolLikeVar(jucerProject.getStringAttribute("pluginIsSynth"));
+      const auto isSynthAudioPlugin =
+        jucerVersionAsTuple >= Version{5, 3, 1}
+          ? pluginCharacteristics.contains("pluginIsSynth")
+          : toBoolLikeVar(jucerProject.getStringAttribute("pluginIsSynth"));
 
       if (jucerVersionAsTuple < Version{5, 3, 1})
       {
@@ -1083,12 +1084,12 @@ int main(int argc, char* argv[])
       {
         if (!jucerProject.hasAttribute("pluginVST3Category"))
         {
-          convertSettingAsList(
-            jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [isSynthAudioPlugin](const juce::String&) {
-              return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
-                                        : juce::StringArray{"Fx"};
-            });
+          convertSettingAsList(jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
+                               [isSynthAudioPlugin](const juce::String&) {
+                                 return isSynthAudioPlugin
+                                          ? juce::StringArray{"Instrument", "Synth"}
+                                          : juce::StringArray{"Fx"};
+                               });
         }
         else
         {
@@ -1113,12 +1114,12 @@ int main(int argc, char* argv[])
       {
         if (!jucerProject.hasAttribute("pluginRTASCategory"))
         {
-          convertSettingAsList(
-            jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-            [isSynthAudioPlugin](const juce::String&) {
-              return juce::StringArray{isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
-                                                          : "ePlugInCategory_None"};
-            });
+          convertSettingAsList(jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
+                               [isSynthAudioPlugin](const juce::String&) {
+                                 return juce::StringArray{
+                                   isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
+                                                      : "ePlugInCategory_None"};
+                               });
         }
         else
         {
@@ -1156,26 +1157,27 @@ int main(int argc, char* argv[])
         }
         else
         {
-          convertSettingAsList(
-            jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-            [](const juce::String& value) -> juce::StringArray {
-              const auto ids = juce::StringArray::fromTokens(value, ",", {});
-              return convertIdsToStrings(ids, {{"0", "AAX_ePlugInCategory_None"},
-                                               {"1", "AAX_ePlugInCategory_EQ"},
-                                               {"2", "AAX_ePlugInCategory_Dynamics"},
-                                               {"4", "AAX_ePlugInCategory_PitchShift"},
-                                               {"8", "AAX_ePlugInCategory_Reverb"},
-                                               {"16", "AAX_ePlugInCategory_Delay"},
-                                               {"32", "AAX_ePlugInCategory_Modulation"},
-                                               {"64", "AAX_ePlugInCategory_Harmonic"},
-                                               {"128", "AAX_ePlugInCategory_NoiseReduction"},
-                                               {"256", "AAX_ePlugInCategory_Dither"},
-                                               {"512", "AAX_ePlugInCategory_SoundField"},
-                                               {"1024", "AAX_ePlugInCategory_HWGenerators"},
-                                               {"2048", "AAX_ePlugInCategory_SWGenerators"},
-                                               {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
-                                               {"8192", "AAX_EPlugInCategory_Effect"}});
-            });
+          convertSettingAsList(jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
+                               [](const juce::String& value) -> juce::StringArray {
+                                 const auto ids =
+                                   juce::StringArray::fromTokens(value, ",", {});
+                                 return convertIdsToStrings(
+                                   ids, {{"0", "AAX_ePlugInCategory_None"},
+                                         {"1", "AAX_ePlugInCategory_EQ"},
+                                         {"2", "AAX_ePlugInCategory_Dynamics"},
+                                         {"4", "AAX_ePlugInCategory_PitchShift"},
+                                         {"8", "AAX_ePlugInCategory_Reverb"},
+                                         {"16", "AAX_ePlugInCategory_Delay"},
+                                         {"32", "AAX_ePlugInCategory_Modulation"},
+                                         {"64", "AAX_ePlugInCategory_Harmonic"},
+                                         {"128", "AAX_ePlugInCategory_NoiseReduction"},
+                                         {"256", "AAX_ePlugInCategory_Dither"},
+                                         {"512", "AAX_ePlugInCategory_SoundField"},
+                                         {"1024", "AAX_ePlugInCategory_HWGenerators"},
+                                         {"2048", "AAX_ePlugInCategory_SWGenerators"},
+                                         {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
+                                         {"8192", "AAX_EPlugInCategory_Effect"}});
+                               });
         }
       }
       else
@@ -1334,7 +1336,8 @@ int main(int argc, char* argv[])
       const auto& module = *pModule;
       const auto& moduleName = module.getStringAttribute("id");
 
-      const auto useGlobalPath = toBoolLikeVar(module.getStringAttribute("useGlobalPath"));
+      const auto useGlobalPath =
+        toBoolLikeVar(module.getStringAttribute("useGlobalPath"));
       const auto isJuceModule = moduleName.startsWith("juce_");
 
       if (useGlobalPath)
@@ -1533,8 +1536,7 @@ int main(int argc, char* argv[])
 
         if (needsTargetFolder)
         {
-          wLn("  TARGET_PROJECT_FOLDER \"",
-              exporter.getStringAttribute("targetFolder"),
+          wLn("  TARGET_PROJECT_FOLDER \"", exporter.getStringAttribute("targetFolder"),
               "\" # only used by PREBUILD_COMMAND and POSTBUILD_COMMAND");
         }
       }
@@ -1548,9 +1550,10 @@ int main(int argc, char* argv[])
         != nullptr;
 
       const auto hasVst2Interface = jucerVersionAsTuple > Version{4, 2, 3};
-      const auto isVstAudioPlugin = isAudioPlugin
-                                    && (pluginFormats.contains("buildVST")
-                                        || toBoolLikeVar(jucerProject.getStringAttribute("buildVST")));
+      const auto isVstAudioPlugin =
+        isAudioPlugin
+        && (pluginFormats.contains("buildVST")
+            || toBoolLikeVar(jucerProject.getStringAttribute("buildVST")));
       const auto& pluginHostVstOption = safeGetChildByName(jucerProject, "JUCEOPTIONS")
                                           .getStringAttribute("JUCE_PLUGINHOST_VST");
       const auto isVstPluginHost =
@@ -1570,9 +1573,10 @@ int main(int argc, char* argv[])
       }
 
       const auto supportsVst3 = exporterType == "XCODE_MAC" || isVSExporter;
-      const auto isVst3AudioPlugin = isAudioPlugin
-                                     && (pluginFormats.contains("buildVST3")
-                                         || toBoolLikeVar(jucerProject.getStringAttribute("buildVST3")));
+      const auto isVst3AudioPlugin =
+        isAudioPlugin
+        && (pluginFormats.contains("buildVST3")
+            || toBoolLikeVar(jucerProject.getStringAttribute("buildVST3")));
       const auto& pluginHostVst3Option = safeGetChildByName(jucerProject, "JUCEOPTIONS")
                                            .getStringAttribute("JUCE_PLUGINHOST_VST3");
       const auto isVst3PluginHost =
@@ -1604,10 +1608,11 @@ int main(int argc, char* argv[])
       convertSettingAsListIfDefined(
         exporter, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
         [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
-      convertSettingAsListIfDefined(
-        exporter, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::String& value) {
-          return juce::StringArray::fromTokens(value, false);
-        });
+      convertSettingAsListIfDefined(exporter, "extraCompilerFlags",
+                                    "EXTRA_COMPILER_FLAGS",
+                                    [](const juce::String& value) {
+                                      return juce::StringArray::fromTokens(value, false);
+                                    });
 
       const auto compilerFlagSchemesArray = juce::StringArray::fromTokens(
         jucerProject.getStringAttribute("compilerFlagSchemes"), ",", {});
@@ -1624,10 +1629,10 @@ int main(int argc, char* argv[])
                                 {});
       }
 
-      convertSettingAsListIfDefined(
-        exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::String& value) {
-          return juce::StringArray::fromTokens(value, false);
-        });
+      convertSettingAsListIfDefined(exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS",
+                                    [](const juce::String& value) {
+                                      return juce::StringArray::fromTokens(value, false);
+                                    });
       convertSettingAsListIfDefined(exporter, "externalLibraries",
                                     "EXTERNAL_LIBRARIES_TO_LINK", {});
 
@@ -1734,7 +1739,8 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(exporter, "appSandboxInheritance",
                                      "APP_SANDBOX_INHERITANCE", {});
         convertSettingAsListIfDefined(
-          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::String& value) {
+          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS",
+          [](const juce::String& value) {
             const auto ids = juce::StringArray::fromTokens(value, ",", {});
             return convertIdsToStrings(
               ids,
@@ -1909,7 +1915,8 @@ int main(int argc, char* argv[])
         convertSettingIfDefined(exporter, "customPList", "CUSTOM_PLIST", {});
         convertOnOffSettingIfDefined(exporter, "PListPreprocess", "PLIST_PREPROCESS", {});
         convertOnOffSettingIfDefined(exporter, "pListPreprocess", "PLIST_PREPROCESS", {});
-        const auto convertPrefixHeader = [&jucerFile, &exporter](const juce::String& value) {
+        const auto convertPrefixHeader = [&jucerFile,
+                                          &exporter](const juce::String& value) {
           if (value.isEmpty())
             return juce::String{};
 
@@ -2044,7 +2051,8 @@ int main(int argc, char* argv[])
                                 });
 
         convertSettingAsListIfDefined(
-          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::String& value) {
+          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES",
+          [](const juce::String& value) {
             return juce::StringArray::fromTokens(value, " ", "\"'");
           });
       }
@@ -2059,16 +2067,17 @@ int main(int argc, char* argv[])
           {"0x0A00", "Windows 10"},
         };
 
-        convertSettingIfDefined(exporter, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
-                                [&windowsTargets](const juce::String& value) -> juce::String {
-                                  auto search = windowsTargets.find(value);
-                                  if (search != windowsTargets.end())
-                                  {
-                                    return search->second;
-                                  }
+        convertSettingIfDefined(
+          exporter, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
+          [&windowsTargets](const juce::String& value) -> juce::String {
+            auto search = windowsTargets.find(value);
+            if (search != windowsTargets.end())
+            {
+              return search->second;
+            }
 
-                                  return {};
-                                });
+            return {};
+          });
       }
 
       writeUserNotes(wLn, exporter);
@@ -2153,8 +2162,8 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
 
-        if (!configuration.hasAttribute("linkTimeOptimisation") && isVSExporter && !isDebug
-            && jucerVersionAsTuple >= Version{5, 2, 0})
+        if (!configuration.hasAttribute("linkTimeOptimisation") && isVSExporter
+            && !isDebug && jucerVersionAsTuple >= Version{5, 2, 0})
         {
           convertOnOffSettingIfDefined(configuration, "wholeProgramOptimisation",
                                        "LINK_TIME_OPTIMISATION",
@@ -2202,41 +2211,42 @@ int main(int argc, char* argv[])
                                   });
         }
 
-        convertSettingIfDefined(configuration, "optimisation", "OPTIMISATION",
-                                [&isVSExporter](const juce::String& value) -> juce::String {
-                                  if (isVSExporter)
-                                  {
-                                    switch (value.getIntValue())
-                                    {
-                                    case 1:
-                                      return "No optimisation";
-                                    case 2:
-                                      return "Minimise size";
-                                    case 3:
-                                      return "Maximise speed";
-                                    }
+        convertSettingIfDefined(
+          configuration, "optimisation", "OPTIMISATION",
+          [&isVSExporter](const juce::String& value) -> juce::String {
+            if (isVSExporter)
+            {
+              switch (value.getIntValue())
+              {
+              case 1:
+                return "No optimisation";
+              case 2:
+                return "Minimise size";
+              case 3:
+                return "Maximise speed";
+              }
 
-                                    return {};
-                                  }
+              return {};
+            }
 
-                                  switch (value.getIntValue())
-                                  {
-                                  case 1:
-                                    return "-O0 (no optimisation)";
-                                  case 2:
-                                    return "-Os (minimise code size)";
-                                  case 3:
-                                    return "-O3 (fastest with safe optimisations)";
-                                  case 4:
-                                    return "-O1 (fast)";
-                                  case 5:
-                                    return "-O2 (faster)";
-                                  case 6:
-                                    return "-Ofast (uses aggressive optimisations)";
-                                  }
+            switch (value.getIntValue())
+            {
+            case 1:
+              return "-O0 (no optimisation)";
+            case 2:
+              return "-Os (minimise code size)";
+            case 3:
+              return "-O3 (fastest with safe optimisations)";
+            case 4:
+              return "-O1 (fast)";
+            case 5:
+              return "-O2 (faster)";
+            case 6:
+              return "-Ofast (uses aggressive optimisations)";
+            }
 
-                                  return {};
-                                });
+            return {};
+          });
 
         if (isXcodeExporter)
         {
@@ -2367,11 +2377,11 @@ int main(int argc, char* argv[])
               return customFlags;
             });
 
-          convertSettingAsListIfDefined(
-            configuration, "plistPreprocessorDefinitions",
-            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::String& value) {
-              return parsePreprocessorDefinitions(value);
-            });
+          convertSettingAsListIfDefined(configuration, "plistPreprocessorDefinitions",
+                                        "PLIST_PREPROCESSOR_DEFINITIONS",
+                                        [](const juce::String& value) {
+                                          return parsePreprocessorDefinitions(value);
+                                        });
 
           convertSettingIfDefined(configuration, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -1267,8 +1267,13 @@ int main(int argc, char* argv[])
         }
       }
 
-      const auto relativeModulePath =
-        modulePathsVT.getChildWithProperty("id", moduleName).getProperty("path").toString();
+      const auto relativeModulePath = [&modulePaths, &moduleName]() -> juce::String {
+        if (const auto pModulePath = modulePaths.getChildByAttribute("id", moduleName))
+        {
+          return pModulePath->getStringAttribute("path");
+        }
+        return juce::String{};
+      }();
 
       wLn("jucer_project_module(");
       wLn("  ", moduleName);
@@ -1454,9 +1459,9 @@ int main(int argc, char* argv[])
       const auto pluginFormats = juce::StringArray::fromTokens(
         jucerProjectVT.getProperty("pluginFormats").toString(), ",", {});
       const auto hasJuceAudioProcessorsModule =
-        juce::ValueTree::fromXml(safeGetChildByName(jucerProject, "MODULES"))
-          .getChildWithProperty("id", "juce_audio_processors")
-          .isValid();
+        safeGetChildByName(jucerProject, "MODULES")
+          .getChildByAttribute("id", "juce_audio_processors")
+        != nullptr;
 
       const auto hasVst2Interface = jucerVersionAsTuple > Version{4, 2, 3};
       const auto isVstAudioPlugin = isAudioPlugin

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -473,13 +473,13 @@ int main(int argc, char* argv[])
   const auto convertSetting =
     [&wLn](const juce::ValueTree& VT, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::String(const juce::var&)> converterFn) {
+           std::function<juce::String(const juce::String&)> converterFn) {
       if (!converterFn)
       {
-        converterFn = [](const juce::var& v) { return v.toString(); };
+        converterFn = [](const juce::String& value) { return value; };
       }
 
-      const auto value = converterFn(VT.getProperty(property));
+      const auto value = converterFn(VT.getProperty(property).toString());
 
       if (value.isEmpty())
       {
@@ -495,7 +495,7 @@ int main(int argc, char* argv[])
   const auto convertSettingIfDefined =
     [&convertSetting](const juce::ValueTree& VT, const juce::Identifier& property,
                       const juce::String& cmakeKeyword,
-                      std::function<juce::String(const juce::var&)> converterFn) {
+                      std::function<juce::String(const juce::String&)> converterFn) {
       if (VT.hasProperty(property))
       {
         convertSetting(VT, property, cmakeKeyword, std::move(converterFn));
@@ -509,34 +509,34 @@ int main(int argc, char* argv[])
       if (!VT.hasProperty(property))
       {
         convertSetting(VT, property, cmakeKeyword,
-                       [&defaultValue](const juce::var&) { return defaultValue; });
+                       [&defaultValue](const juce::String&) { return defaultValue; });
       }
       else
       {
         convertSetting(VT, property, cmakeKeyword,
-                       [](const juce::var& v) { return v.toString(); });
+                       [](const juce::String& value) { return value; });
       }
     };
 
   const auto convertOnOffSetting =
     [&wLn](const juce::ValueTree& VT, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::String(const juce::var&)> converterFn) {
+           std::function<juce::String(const juce::String&)> converterFn) {
       if (!converterFn)
       {
         if (!VT.hasProperty(property))
         {
-          converterFn = [](const juce::var&) -> juce::String { return {}; };
+          converterFn = [](const juce::String&) -> juce::String { return {}; };
         }
         else
         {
-          converterFn = [](const juce::var& v) -> juce::String {
-            return toBoolLikeVar(v.toString()) ? "ON" : "OFF";
+          converterFn = [](const juce::String& value) -> juce::String {
+            return toBoolLikeVar(value) ? "ON" : "OFF";
           };
         }
       }
 
-      const auto value = converterFn(VT.getProperty(property));
+      const auto value = converterFn(VT.getProperty(property).toString());
 
       if (value.isEmpty())
       {
@@ -552,7 +552,7 @@ int main(int argc, char* argv[])
     [&convertOnOffSetting](const juce::ValueTree& VT,
                            const juce::Identifier& property,
                            const juce::String& cmakeKeyword,
-                           std::function<juce::String(const juce::var&)> converterFn) {
+                           std::function<juce::String(const juce::String&)> converterFn) {
       if (VT.hasProperty(property))
       {
         convertOnOffSetting(VT, property, cmakeKeyword, std::move(converterFn));
@@ -566,15 +566,15 @@ int main(int argc, char* argv[])
       if (!VT.hasProperty(property))
       {
         convertOnOffSetting(VT, property, cmakeKeyword,
-                            [defaultValue](const juce::var&) -> juce::String {
+                            [defaultValue](const juce::String&) -> juce::String {
                               return defaultValue ? "ON" : "OFF";
                             });
       }
       else
       {
         convertOnOffSetting(VT, property, cmakeKeyword,
-                            [](const juce::var& v) -> juce::String {
-                              return toBoolLikeVar(v.toString()) ? "ON" : "OFF";
+                            [](const juce::String& value) -> juce::String {
+                              return toBoolLikeVar(value) ? "ON" : "OFF";
                             });
       }
     };
@@ -582,15 +582,15 @@ int main(int argc, char* argv[])
   const auto convertSettingAsList =
     [&wLn](const juce::ValueTree& VT, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::StringArray(const juce::var&)> converterFn) {
+           std::function<juce::StringArray(const juce::String&)> converterFn) {
       if (!converterFn)
       {
-        converterFn = [](const juce::var& v) {
-          return juce::StringArray::fromLines(v.toString());
+        converterFn = [](const juce::String& value) {
+          return juce::StringArray::fromLines(value);
         };
       }
 
-      auto value = converterFn(VT.getProperty(property));
+      auto value = converterFn(VT.getProperty(property).toString());
       value.removeEmptyStrings();
 
       if (value.isEmpty())
@@ -612,7 +612,7 @@ int main(int argc, char* argv[])
     [&convertSettingAsList](
       const juce::ValueTree& VT, const juce::Identifier& property,
       const juce::String& cmakeKeyword,
-      std::function<juce::StringArray(const juce::var&)> converterFn) {
+      std::function<juce::StringArray(const juce::String&)> converterFn) {
       if (VT.hasProperty(property))
       {
         convertSettingAsList(VT, property, cmakeKeyword, std::move(converterFn));
@@ -755,8 +755,8 @@ int main(int argc, char* argv[])
       else
       {
         convertOnOffSetting(jucerProjectVT, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
-                            [&tagLine](const juce::var& v) {
-                              return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine;
+                            [&tagLine](const juce::String& value) {
+                              return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine;
                             });
       }
 
@@ -768,8 +768,8 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(jucerProjectVT, "displaySplashScreen",
                             "DISPLAY_THE_JUCE_SPLASH_SCREEN",
-                            [&tagLine](const juce::var& v) {
-                              return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine;
+                            [&tagLine](const juce::String& value) {
+                              return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine;
                             });
       }
 
@@ -812,11 +812,11 @@ int main(int argc, char* argv[])
                               defaultBundleIdentifier);
 
     convertSettingIfDefined(jucerProjectVT, "maxBinaryFileSize", "BINARYDATACPP_SIZE_LIMIT",
-                            [](const juce::var& v) -> juce::String {
-                              if (v.toString().isEmpty())
+                            [](const juce::String& value) -> juce::String {
+                              if (value.isEmpty())
                                 return "Default";
                               return juce::File::descriptionOfSizeInBytes(
-                                v.toString().getIntValue());
+                                value.getIntValue());
                             });
     if (jucerProjectVT.hasProperty("includeBinaryInJuceHeader"))
     {
@@ -834,9 +834,7 @@ int main(int argc, char* argv[])
     if (jucerProjectVT.hasProperty("cppLanguageStandard"))
     {
       convertSetting(jucerProjectVT, "cppLanguageStandard", "CXX_LANGUAGE_STANDARD",
-                     [](const juce::var& v) -> juce::String {
-                       const auto value = v.toString();
-
+                     [](const juce::String& value) -> juce::String {
                        if (value == "11")
                          return "C++11";
 
@@ -863,10 +861,10 @@ int main(int argc, char* argv[])
 
     convertSettingAsListIfDefined(
       jucerProjectVT, "defines", "PREPROCESSOR_DEFINITIONS",
-      [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+      [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
     convertSettingAsListIfDefined(
-      jucerProjectVT, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::var& v) {
-        return juce::StringArray::fromTokens(v.toString(), ";\r\n", {});
+      jucerProjectVT, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::String& value) {
+        return juce::StringArray::fromTokens(value, ";\r\n", {});
       });
 
     convertSettingIfDefined(jucerProjectVT, "postExportShellCommandPosix",
@@ -892,7 +890,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
-            [&vstIsLegacy](const juce::var&) {
+            [&vstIsLegacy](const juce::String&) {
               return juce::StringArray{vstIsLegacy ? "VST3" : "VST", "AU", "Standalone"};
             });
         }
@@ -900,9 +898,9 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginFormats", "PLUGIN_FORMATS",
-            [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
+            [&jucerVersionAsTuple, &vstIsLegacy](const juce::String& value) {
               const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(
                 ids,
                 {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
@@ -927,8 +925,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
-            [](const juce::var& v) {
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(
                 ids,
                 {{"pluginIsSynth", "Plugin is a Synth"},
@@ -1015,7 +1013,7 @@ int main(int argc, char* argv[])
         if (!jucerProjectVT.hasProperty("pluginAUMainType"))
         {
           convertSetting(jucerProjectVT, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
-                         [&pluginCharacteristics](const juce::var&) -> juce::String {
+                         [&pluginCharacteristics](const juce::String&) -> juce::String {
                            if (pluginCharacteristics.contains("pluginIsMidiEffectPlugin"))
                              return "kAudioUnitType_MIDIProcessor"; // 'aumi'
 
@@ -1031,8 +1029,7 @@ int main(int argc, char* argv[])
         else
         {
           convertSetting(jucerProjectVT, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
-                         [](const juce::var& v) -> juce::String {
-                           const auto value = v.toString();
+                         [](const juce::String& value) -> juce::String {
                            // clang-format off
                            if (value == "'aufx'") return "kAudioUnitType_Effect";
                            if (value == "'aufc'") return "kAudioUnitType_FormatConverter";
@@ -1088,7 +1085,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) {
+            [isSynthAudioPlugin](const juce::String&) {
               return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
                                         : juce::StringArray{"Fx"};
             });
@@ -1097,8 +1094,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [](const juce::var& v) {
-              auto vst3_category = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              auto vst3_category = juce::StringArray::fromTokens(value, ",", {});
               if (vst3_category.contains("Instrument"))
               {
                 vst3_category.move(vst3_category.indexOf("Instrument"), 0);
@@ -1118,7 +1115,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) {
+            [isSynthAudioPlugin](const juce::String&) {
               return juce::StringArray{isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
                                                           : "ePlugInCategory_None"};
             });
@@ -1127,8 +1124,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-            [](const juce::var& v) {
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(ids, {{"0", "ePlugInCategory_None"},
                                                {"1", "ePlugInCategory_EQ"},
                                                {"2", "ePlugInCategory_Dynamics"},
@@ -1151,7 +1148,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) -> juce::StringArray {
+            [isSynthAudioPlugin](const juce::String&) -> juce::StringArray {
               return juce::StringArray{isSynthAudioPlugin
                                          ? "AAX_ePlugInCategory_SWGenerators"
                                          : "AAX_ePlugInCategory_None"};
@@ -1161,8 +1158,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProjectVT, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-            [](const juce::var& v) -> juce::StringArray {
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) -> juce::StringArray {
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(ids, {{"0", "AAX_ePlugInCategory_None"},
                                                {"1", "AAX_ePlugInCategory_EQ"},
                                                {"2", "AAX_ePlugInCategory_Dynamics"},
@@ -1612,10 +1609,10 @@ int main(int argc, char* argv[])
 
       convertSettingAsListIfDefined(
         exporterVT, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
-        [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+        [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
       convertSettingAsListIfDefined(
-        exporterVT, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::var& v) {
-          return juce::StringArray::fromTokens(v.toString(), false);
+        exporterVT, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::String& value) {
+          return juce::StringArray::fromTokens(value, false);
         });
 
       const auto compilerFlagSchemesArray = juce::StringArray::fromTokens(
@@ -1634,8 +1631,8 @@ int main(int argc, char* argv[])
       }
 
       convertSettingAsListIfDefined(
-        exporterVT, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::var& v) {
-          return juce::StringArray::fromTokens(v.toString(), false);
+        exporterVT, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::String& value) {
+          return juce::StringArray::fromTokens(value, false);
         });
       convertSettingAsListIfDefined(exporterVT, "externalLibraries",
                                     "EXTERNAL_LIBRARIES_TO_LINK", {});
@@ -1643,9 +1640,8 @@ int main(int argc, char* argv[])
       convertOnOffSettingIfDefined(exporterVT, "enableGNUExtensions",
                                    "GNU_COMPILER_EXTENSIONS", {});
 
-      const auto convertIcon = [&safeGetChildByName, &jucerProject](const juce::var& v) -> juce::String {
-        const auto fileId = v.toString();
-
+      const auto convertIcon =
+        [&safeGetChildByName, &jucerProject](const juce::String& fileId) -> juce::String {
         if (fileId.isNotEmpty())
         {
           if (const auto pFile = getChildByAttributeRecursively(
@@ -1673,8 +1669,8 @@ int main(int argc, char* argv[])
       {
         convertSettingAsListIfDefined(
           exporterVT, "customXcodeResourceFolders", "CUSTOM_XCODE_RESOURCE_FOLDERS",
-          [](const juce::var& v) {
-            auto folders = juce::StringArray::fromLines(v.toString());
+          [](const juce::String& value) {
+            auto folders = juce::StringArray::fromLines(value);
             folders.trim();
             folders.removeEmptyStrings();
             return folders;
@@ -1691,9 +1687,7 @@ int main(int argc, char* argv[])
       if (exporterType == "XCODE_IPHONE")
       {
         convertSettingIfDefined(exporterVT, "iosDeviceFamily", "DEVICE_FAMILY",
-                                [](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [](const juce::String& value) -> juce::String {
                                   if (value == "1")
                                     return "iPhone";
 
@@ -1706,9 +1700,7 @@ int main(int argc, char* argv[])
                                   return value;
                                 });
 
-        const auto screenOrientationFn = [](const juce::var& v) -> juce::String {
-          const auto value = v.toString();
-
+        const auto screenOrientationFn = [](const juce::String& value) -> juce::String {
           if (value == "portraitlandscape")
             return "Portrait and Landscape";
 
@@ -1739,8 +1731,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporterVT, "documentExtensions", "DOCUMENT_FILE_EXTENSIONS",
-            [](const juce::var& v) {
-              return juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              return juce::StringArray::fromTokens(value, ",", {});
             });
         }
 
@@ -1748,8 +1740,8 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(exporterVT, "appSandboxInheritance",
                                      "APP_SANDBOX_INHERITANCE", {});
         convertSettingAsListIfDefined(
-          exporterVT, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::var& v) {
-            const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+          exporterVT, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::String& value) {
+            const auto ids = juce::StringArray::fromTokens(value, ",", {});
             return convertIdsToStrings(
               ids,
               {{"com.apple.security.network.server",
@@ -1816,8 +1808,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporterVT, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
-            [](const juce::var& v) {
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(
                 ids,
                 {{"com.apple.security.cs.allow-jit",
@@ -1850,8 +1842,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporterVT, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
-            [](const juce::var& v) {
-              const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              const auto ids = juce::StringArray::fromTokens(value, ",", {});
               return convertIdsToStrings(
                 ids,
                 {{"com.apple.security.cs.allow-jit",
@@ -1923,9 +1915,7 @@ int main(int argc, char* argv[])
         convertSettingIfDefined(exporterVT, "customPList", "CUSTOM_PLIST", {});
         convertOnOffSettingIfDefined(exporterVT, "PListPreprocess", "PLIST_PREPROCESS", {});
         convertOnOffSettingIfDefined(exporterVT, "pListPreprocess", "PLIST_PREPROCESS", {});
-        const auto convertPrefixHeader = [&jucerFile, &exporterVT](const juce::var& v) {
-          const auto value = v.toString();
-
+        const auto convertPrefixHeader = [&jucerFile, &exporterVT](const juce::String& value) {
           if (value.isEmpty())
             return juce::String{};
 
@@ -1944,8 +1934,8 @@ int main(int argc, char* argv[])
           exporterVT, "extraFrameworks",
           jucerVersionAsTuple > Version{5, 3, 2} ? "EXTRA_SYSTEM_FRAMEWORKS"
                                                  : "EXTRA_FRAMEWORKS",
-          [](const juce::var& v) {
-            auto frameworks = juce::StringArray::fromTokens(v.toString(), ",;", "\"'");
+          [](const juce::String& value) {
+            auto frameworks = juce::StringArray::fromTokens(value, ",;", "\"'");
             frameworks.trim();
             return frameworks;
           });
@@ -1969,8 +1959,8 @@ int main(int argc, char* argv[])
       if (exporterType == "XCODE_IPHONE")
       {
         convertSettingAsListIfDefined(
-          exporterVT, "iosAppGroupsId", "APP_GROUP_ID", [](const juce::var& v) {
-            auto groups = juce::StringArray::fromTokens(v.toString(), ";", {});
+          exporterVT, "iosAppGroupsId", "APP_GROUP_ID", [](const juce::String& value) {
+            auto groups = juce::StringArray::fromTokens(value, ";", {});
             groups.trim();
             return groups;
           });
@@ -2002,9 +1992,7 @@ int main(int argc, char* argv[])
 
         convertSettingIfDefined(
           exporterVT, "IPPLibrary", "USE_IPP_LIBRARY",
-          [&jucerVersionAsTuple](const juce::var& v) -> juce::String {
-            const auto value = v.toString();
-
+          [&jucerVersionAsTuple](const juce::String& value) -> juce::String {
             if (value.isEmpty())
               return "No";
 
@@ -2033,9 +2021,7 @@ int main(int argc, char* argv[])
         if (exporterType == "VS2017")
         {
           convertSettingIfDefined(exporterVT, "cppLanguageStandard", "CXX_STANDARD_TO_USE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "(default)";
                                     if (value == "stdcpp14")
@@ -2050,9 +2036,7 @@ int main(int argc, char* argv[])
       if (exporterType == "LINUX_MAKE")
       {
         convertSettingIfDefined(exporterVT, "cppLanguageStandard", "CXX_STANDARD_TO_USE",
-                                [](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [](const juce::String& value) -> juce::String {
                                   if (value == "-std=c++03")
                                     return "C++03";
 
@@ -2066,8 +2050,8 @@ int main(int argc, char* argv[])
                                 });
 
         convertSettingAsListIfDefined(
-          exporterVT, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::var& v) {
-            return juce::StringArray::fromTokens(v.toString(), " ", "\"'");
+          exporterVT, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::String& value) {
+            return juce::StringArray::fromTokens(value, " ", "\"'");
           });
       }
 
@@ -2082,9 +2066,7 @@ int main(int argc, char* argv[])
         };
 
         convertSettingIfDefined(exporterVT, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
-                                [&windowsTargets](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [&windowsTargets](const juce::String& value) -> juce::String {
                                   auto search = windowsTargets.find(value);
                                   if (search != windowsTargets.end())
                                   {
@@ -2133,8 +2115,8 @@ int main(int argc, char* argv[])
 
         const auto convertSearchPaths =
           [&isAbsolutePath, &jucerFileDir,
-           &targetProjectDir](const juce::var& v) -> juce::StringArray {
-          const auto searchPaths = v.toString();
+           &targetProjectDir](const juce::String& value) -> juce::StringArray {
+          const auto searchPaths = value;
 
           if (searchPaths.isEmpty())
           {
@@ -2173,7 +2155,7 @@ int main(int argc, char* argv[])
 
         convertSettingAsListIfDefined(
           configurationVT, "defines", "PREPROCESSOR_DEFINITIONS",
-          [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+          [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
 
         convertOnOffSettingIfDefined(configurationVT, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
@@ -2182,8 +2164,9 @@ int main(int argc, char* argv[])
             && jucerVersionAsTuple >= Version{5, 2, 0})
         {
           convertOnOffSettingIfDefined(configurationVT, "wholeProgramOptimisation",
-                                       "LINK_TIME_OPTIMISATION", [](const juce::var& v) {
-                                         if (v.toString().getIntValue() == 0)
+                                       "LINK_TIME_OPTIMISATION",
+                                       [](const juce::String& value) {
+                                         if (value.getIntValue() == 0)
                                            return "ON";
 
                                          return "OFF";
@@ -2194,9 +2177,7 @@ int main(int argc, char* argv[])
         {
           convertSettingIfDefined(configurationVT, "recommendedWarnings",
                                   "ADD_RECOMMENDED_COMPILER_WARNING_FLAGS",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "LLVM")
                                       return "Enabled";
 
@@ -2211,9 +2192,7 @@ int main(int argc, char* argv[])
         {
           convertSettingIfDefined(configurationVT, "recommendedWarnings",
                                   "ADD_RECOMMENDED_COMPILER_WARNING_FLAGS",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "GCC")
                                       return "GCC";
 
@@ -2231,10 +2210,10 @@ int main(int argc, char* argv[])
         }
 
         convertSettingIfDefined(configurationVT, "optimisation", "OPTIMISATION",
-                                [&isVSExporter](const juce::var& v) -> juce::String {
+                                [&isVSExporter](const juce::String& value) -> juce::String {
                                   if (isVSExporter)
                                   {
-                                    switch (v.toString().getIntValue())
+                                    switch (value.getIntValue())
                                     {
                                     case 1:
                                       return "No optimisation";
@@ -2247,7 +2226,7 @@ int main(int argc, char* argv[])
                                     return {};
                                   }
 
-                                  switch (v.toString().getIntValue())
+                                  switch (value.getIntValue())
                                   {
                                   case 1:
                                     return "-O0 (no optimisation)";
@@ -2335,9 +2314,7 @@ int main(int argc, char* argv[])
           };
 
           convertSettingIfDefined(configurationVT, "osxSDK", "OSX_BASE_SDK_VERSION",
-                                  [&sdks](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [&sdks](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2349,9 +2326,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(configurationVT, "osxCompatibility",
                                   "OSX_DEPLOYMENT_TARGET",
-                                  [&sdks](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [&sdks](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2362,9 +2337,7 @@ int main(int argc, char* argv[])
                                   });
 
           convertSettingIfDefined(configurationVT, "osxArchitecture", "OSX_ARCHITECTURE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2388,8 +2361,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             configurationVT, "customXcodeFlags", "CUSTOM_XCODE_FLAGS",
-            [](const juce::var& v) {
-              auto customFlags = juce::StringArray::fromTokens(v.toString(), ",", "\"'");
+            [](const juce::String& value) {
+              auto customFlags = juce::StringArray::fromTokens(value, ",", "\"'");
               customFlags.removeEmptyStrings();
 
               for (auto& flag : customFlags)
@@ -2403,15 +2376,13 @@ int main(int argc, char* argv[])
 
           convertSettingAsListIfDefined(
             configurationVT, "plistPreprocessorDefinitions",
-            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::var& v) {
-              return parsePreprocessorDefinitions(v.toString());
+            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::String& value) {
+              return parsePreprocessorDefinitions(value);
             });
 
           convertSettingIfDefined(configurationVT, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Use Default";
 
@@ -2437,9 +2408,7 @@ int main(int argc, char* argv[])
                                   });
 
           convertSettingIfDefined(configurationVT, "cppLibType", "CXX_LIBRARY",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Use Default";
 
@@ -2485,8 +2454,8 @@ int main(int argc, char* argv[])
           }
 
           convertSettingIfDefined(configurationVT, "winWarningLevel", "WARNING_LEVEL",
-                                  [](const juce::var& v) -> juce::String {
-                                    switch (v.toString().getIntValue())
+                                  [](const juce::String& value) -> juce::String {
+                                    switch (value.getIntValue())
                                     {
                                     case 2:
                                       return "Low";
@@ -2503,9 +2472,7 @@ int main(int argc, char* argv[])
                                        "TREAT_WARNINGS_AS_ERRORS", {});
 
           convertSettingIfDefined(configurationVT, "useRuntimeLibDLL", "RUNTIME_LIBRARY",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "(Default)";
 
@@ -2522,11 +2489,11 @@ int main(int argc, char* argv[])
           {
             convertSettingIfDefined(configurationVT, "wholeProgramOptimisation",
                                     "WHOLE_PROGRAM_OPTIMISATION",
-                                    [](const juce::var& v) -> juce::String {
-                                      if (v.toString().isEmpty())
+                                    [](const juce::String& value) -> juce::String {
+                                      if (value.isEmpty())
                                         return "Enable when possible";
 
-                                      if (v.toString().getIntValue() > 0)
+                                      if (value.getIntValue() > 0)
                                         return "Always disable";
 
                                       return {};
@@ -2552,9 +2519,7 @@ int main(int argc, char* argv[])
                                        "GENERATE_MANIFEST", {});
 
           convertSettingIfDefined(configurationVT, "characterSet", "CHARACTER_SET",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Default";
 
@@ -2577,9 +2542,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(
             configurationVT, "debugInformationFormat", "DEBUG_INFORMATION_FORMAT",
-            [](const juce::var& v) -> juce::String {
-              const auto value = v.toString();
-
+            [](const juce::String& value) -> juce::String {
               if (value == "None")
                 return "None";
 
@@ -2602,9 +2565,7 @@ int main(int argc, char* argv[])
         if (exporterType == "LINUX_MAKE")
         {
           convertSettingIfDefined(configurationVT, "linuxArchitecture", "ARCHITECTURE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "<None>";
 
@@ -2627,9 +2588,8 @@ int main(int argc, char* argv[])
                                   });
         }
 
-        const auto codeBlocksArchitecture = [](const juce::var& v) -> juce::String {
-          const auto value = v.toString();
-
+        const auto codeBlocksArchitecture =
+          [](const juce::String& value) -> juce::String {
           if (value == "-m32")
             return "32-bit (-m32)";
 

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -806,7 +806,8 @@ int main(int argc, char* argv[])
                             [](const juce::var& v) -> juce::String {
                               if (v.toString().isEmpty())
                                 return "Default";
-                              return juce::File::descriptionOfSizeInBytes(int{v});
+                              return juce::File::descriptionOfSizeInBytes(
+                                v.toString().getIntValue());
                             });
     if (jucerProjectVT.hasProperty("includeBinaryInJuceHeader"))
     {
@@ -2164,7 +2165,7 @@ int main(int argc, char* argv[])
         {
           convertOnOffSettingIfDefined(configurationVT, "wholeProgramOptimisation",
                                        "LINK_TIME_OPTIMISATION", [](const juce::var& v) {
-                                         if (int{v} == 0)
+                                         if (v.toString().getIntValue() == 0)
                                            return "ON";
 
                                          return "OFF";
@@ -2215,7 +2216,7 @@ int main(int argc, char* argv[])
                                 [&isVSExporter](const juce::var& v) -> juce::String {
                                   if (isVSExporter)
                                   {
-                                    switch (int{v})
+                                    switch (v.toString().getIntValue())
                                     {
                                     case 1:
                                       return "No optimisation";
@@ -2228,7 +2229,7 @@ int main(int argc, char* argv[])
                                     return {};
                                   }
 
-                                  switch (int{v})
+                                  switch (v.toString().getIntValue())
                                   {
                                   case 1:
                                     return "-O0 (no optimisation)";
@@ -2467,7 +2468,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(configurationVT, "winWarningLevel", "WARNING_LEVEL",
                                   [](const juce::var& v) -> juce::String {
-                                    switch (int{v})
+                                    switch (v.toString().getIntValue())
                                     {
                                     case 2:
                                       return "Low";
@@ -2507,7 +2508,7 @@ int main(int argc, char* argv[])
                                       if (v.toString().isEmpty())
                                         return "Enable when possible";
 
-                                      if (int{v} > 0)
+                                      if (v.toString().getIntValue() > 0)
                                         return "Always disable";
 
                                       return {};

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -1224,10 +1224,17 @@ int main(int argc, char* argv[])
                                .getChild(0)
                                .getChildWithName("MODULEPATHS");
 
-    const auto modulesVT = juce::ValueTree::fromXml(safeGetChildByName(jucerProject, "MODULES"));
-    for (auto i = 0; i < modulesVT.getNumChildren(); ++i)
+    const auto& modules = safeGetChildByName(jucerProject, "MODULES");
+    for (auto pModule = modules.getFirstChildElement(); pModule != nullptr;
+         pModule = pModule->getNextElement())
     {
-      const auto moduleVT = modulesVT.getChild(i);
+      if (pModule->isTextElement())
+      {
+        continue;
+      }
+
+      const auto& module = *pModule;
+      const auto moduleVT = juce::ValueTree::fromXml(module);
       const auto moduleName = moduleVT.getProperty("id").toString();
 
       const auto useGlobalPath = bool{moduleVT.getProperty("useGlobalPath")};


### PR DESCRIPTION
This branch replaces all usage of `juce::ValueTree` and `juce::var` in Jucer2Reprojucer with `juce::XmlElement`.

This improves compilation time (using Visual Studio 2015 here):

- before
  ```
  D:/dev/bin/cmake-3.4.0/bin/cmake.exe --build . --target Jucer2Reprojucer -- -v:m
    Time (mean ± σ):      6.539 s ±  0.047 s    [User: 4.3 ms, System: 2.5 ms]
    Range (min … max):    6.461 s …  6.630 s    10 runs
  ```

- after
  ```
  D:/dev/bin/cmake-3.4.0/bin/cmake.exe --build . --target Jucer2Reprojucer -- -v:m
    Time (mean ± σ):      5.374 s ±  0.020 s    [User: 1.3 ms, System: 2.4 ms]
    Range (min … max):    5.353 s …  5.421 s    10 runs
  ```

and also execution time (on Windows 10 here):  
  
- before:
  ```
  D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=4.2.0 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=4.3.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.0.0 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.2.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.3.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.4.3 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.4.7 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe cmake -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -P ../ci/apply-Jucer2Reprojucer-to-test-jucers.cmake
    Time (mean ± σ):      4.575 s ±  0.022 s    [User: 0.0 ms, System: 0.0 ms]
    Range (min … max):    4.545 s …  4.615 s    10 runs
  ```

- after:
  ```
  D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=4.2.0 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=4.3.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.0.0 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.2.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.3.1 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.4.3 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -DJUCE_VERSION=5.4.7 -P ../ci/apply-Jucer2Reprojucer-to-JUCE-jucers.cmake && D:/dev/bin/cmake-3.4.0/bin/cmake.exe cmake -DJucer2Reprojucer_EXE=Jucer2Reprojucer/Debug/ConsoleApp/Jucer2Reprojucer.exe -P ../ci/apply-Jucer2Reprojucer-to-test-jucers.cmake
    Time (mean ± σ):      4.267 s ±  0.022 s    [User: 0.0 ms, System: 0.0 ms]
    Range (min … max):    4.233 s …  4.310 s    10 runs
  ```