### PR TITLE
Eliminate juce::ValueTree from Jucer2Reprojucer

### DIFF
--- a/Jucer2Reprojucer/CMakeLists.txt
+++ b/Jucer2Reprojucer/CMakeLists.txt
@@ -86,18 +86,6 @@ jucer_project_module(
   JUCE_USE_CURL OFF
 )
 
-jucer_project_module(
-  juce_data_structures
-  PATH "${JUCE_ROOT}/modules"
-  ADD_SOURCE_TO_PROJECT OFF
-)
-
-jucer_project_module(
-  juce_events
-  PATH "${JUCE_ROOT}/modules"
-  ADD_SOURCE_TO_PROJECT OFF
-)
-
 jucer_export_target(
   "Xcode (MacOSX)"
   COMPILER_FLAGS_FOR_maximum_warnings "-Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded"

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -203,10 +203,9 @@ juce::String escape(const juce::String& charsToEscape, juce::String value)
 
 
 juce::StringArray
-convertIdsToStrings(const juce::var& v,
+convertIdsToStrings(const juce::StringArray& ids,
                     const std::vector<std::pair<juce::String, const char*>>& idsToStrings)
 {
-  const auto ids = juce::StringArray::fromTokens(v.toString(), ",", {});
   juce::StringArray strings;
   for (const auto& idToString : idsToStrings)
   {
@@ -886,16 +885,17 @@ int main(int argc, char* argv[])
             [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
               const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
               return convertIdsToStrings(
-                v, {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
-                    {"buildVST3", "VST3"},
-                    {"buildAU", "AU"},
-                    {"buildAUv3", "AUv3"},
-                    {"buildRTAS", "RTAS"},
-                    {"buildAAX", "AAX"},
-                    {"buildStandalone", "Standalone"},
-                    {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
-                    {"enableIAA", "Enable IAA"},
-                    {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
+                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
+                 {"buildVST3", "VST3"},
+                 {"buildAU", "AU"},
+                 {"buildAUv3", "AUv3"},
+                 {"buildRTAS", "RTAS"},
+                 {"buildAAX", "AAX"},
+                 {"buildStandalone", "Standalone"},
+                 {supportsUnity ? "buildUnity" : "", supportsUnity ? "Unity" : ""},
+                 {"enableIAA", "Enable IAA"},
+                 {vstIsLegacy ? "buildVST" : "", vstIsLegacy ? "VST (Legacy)" : ""}});
             });
         }
 
@@ -909,15 +909,16 @@ int main(int argc, char* argv[])
             jucerProject, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
             [](const juce::var& v) {
               return convertIdsToStrings(
-                v, {{"pluginIsSynth", "Plugin is a Synth"},
-                    {"pluginWantsMidiIn", "Plugin MIDI Input"},
-                    {"pluginProducesMidiOut", "Plugin MIDI Output"},
-                    {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
-                    {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
-                    {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
-                    {"pluginAAXDisableBypass", "Disable AAX Bypass"},
-                    {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
-                    {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
+                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                {{"pluginIsSynth", "Plugin is a Synth"},
+                 {"pluginWantsMidiIn", "Plugin MIDI Input"},
+                 {"pluginProducesMidiOut", "Plugin MIDI Output"},
+                 {"pluginIsMidiEffectPlugin", "MIDI Effect Plugin"},
+                 {"pluginEditorRequiresKeys", "Plugin Editor Requires Keyboard Focus"},
+                 {"pluginRTASDisableBypass", "Disable RTAS Bypass"},
+                 {"pluginAAXDisableBypass", "Disable AAX Bypass"},
+                 {"pluginRTASDisableMultiMono", "Disable RTAS Multi-Mono"},
+                 {"pluginAAXDisableMultiMono", "Disable AAX Multi-Mono"}});
             });
         }
       }
@@ -1106,21 +1107,22 @@ int main(int argc, char* argv[])
           convertSettingAsList(jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
                                [](const juce::var& v) {
                                  return convertIdsToStrings(
-                                   v, {{"0", "ePlugInCategory_None"},
-                                       {"1", "ePlugInCategory_EQ"},
-                                       {"2", "ePlugInCategory_Dynamics"},
-                                       {"4", "ePlugInCategory_PitchShift"},
-                                       {"8", "ePlugInCategory_Reverb"},
-                                       {"16", "ePlugInCategory_Delay"},
-                                       {"32", "ePlugInCategory_Modulation"},
-                                       {"64", "ePlugInCategory_Harmonic"},
-                                       {"128", "ePlugInCategory_NoiseReduction"},
-                                       {"256", "ePlugInCategory_Dither"},
-                                       {"512", "ePlugInCategory_SoundField"},
-                                       {"1024", "ePlugInCategory_HWGenerators"},
-                                       {"2048", "ePlugInCategory_SWGenerators"},
-                                       {"4096", "ePlugInCategory_WrappedPlugin"},
-                                       {"8192", "ePlugInCategory_Effect"}});
+                                   juce::StringArray::fromTokens(v.toString(), ",", {}),
+                                   {{"0", "ePlugInCategory_None"},
+                                    {"1", "ePlugInCategory_EQ"},
+                                    {"2", "ePlugInCategory_Dynamics"},
+                                    {"4", "ePlugInCategory_PitchShift"},
+                                    {"8", "ePlugInCategory_Reverb"},
+                                    {"16", "ePlugInCategory_Delay"},
+                                    {"32", "ePlugInCategory_Modulation"},
+                                    {"64", "ePlugInCategory_Harmonic"},
+                                    {"128", "ePlugInCategory_NoiseReduction"},
+                                    {"256", "ePlugInCategory_Dither"},
+                                    {"512", "ePlugInCategory_SoundField"},
+                                    {"1024", "ePlugInCategory_HWGenerators"},
+                                    {"2048", "ePlugInCategory_SWGenerators"},
+                                    {"4096", "ePlugInCategory_WrappedPlugin"},
+                                    {"8192", "ePlugInCategory_Effect"}});
                                });
         }
 
@@ -1139,21 +1141,22 @@ int main(int argc, char* argv[])
           convertSettingAsList(jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
                                [](const juce::var& v) -> juce::StringArray {
                                  return convertIdsToStrings(
-                                   v, {{"0", "AAX_ePlugInCategory_None"},
-                                       {"1", "AAX_ePlugInCategory_EQ"},
-                                       {"2", "AAX_ePlugInCategory_Dynamics"},
-                                       {"4", "AAX_ePlugInCategory_PitchShift"},
-                                       {"8", "AAX_ePlugInCategory_Reverb"},
-                                       {"16", "AAX_ePlugInCategory_Delay"},
-                                       {"32", "AAX_ePlugInCategory_Modulation"},
-                                       {"64", "AAX_ePlugInCategory_Harmonic"},
-                                       {"128", "AAX_ePlugInCategory_NoiseReduction"},
-                                       {"256", "AAX_ePlugInCategory_Dither"},
-                                       {"512", "AAX_ePlugInCategory_SoundField"},
-                                       {"1024", "AAX_ePlugInCategory_HWGenerators"},
-                                       {"2048", "AAX_ePlugInCategory_SWGenerators"},
-                                       {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
-                                       {"8192", "AAX_EPlugInCategory_Effect"}});
+                                   juce::StringArray::fromTokens(v.toString(), ",", {}),
+                                   {{"0", "AAX_ePlugInCategory_None"},
+                                    {"1", "AAX_ePlugInCategory_EQ"},
+                                    {"2", "AAX_ePlugInCategory_Dynamics"},
+                                    {"4", "AAX_ePlugInCategory_PitchShift"},
+                                    {"8", "AAX_ePlugInCategory_Reverb"},
+                                    {"16", "AAX_ePlugInCategory_Delay"},
+                                    {"32", "AAX_ePlugInCategory_Modulation"},
+                                    {"64", "AAX_ePlugInCategory_Harmonic"},
+                                    {"128", "AAX_ePlugInCategory_NoiseReduction"},
+                                    {"256", "AAX_ePlugInCategory_Dither"},
+                                    {"512", "AAX_ePlugInCategory_SoundField"},
+                                    {"1024", "AAX_ePlugInCategory_HWGenerators"},
+                                    {"2048", "AAX_ePlugInCategory_SWGenerators"},
+                                    {"4096", "AAX_ePlugInCategory_WrappedPlugin"},
+                                    {"8192", "AAX_EPlugInCategory_Effect"}});
                                });
         }
       }
@@ -1688,7 +1691,7 @@ int main(int argc, char* argv[])
         convertSettingAsListIfDefined(
           exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::var& v) {
             return convertIdsToStrings(
-              v,
+              juce::StringArray::fromTokens(v.toString(), ",", {}),
               {{"com.apple.security.network.server",
                 "Network: Incoming Connections (Server)"},
                {"com.apple.security.network.client",
@@ -1755,7 +1758,7 @@ int main(int argc, char* argv[])
             exporter, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
             [](const juce::var& v) {
               return convertIdsToStrings(
-                v,
+                juce::StringArray::fromTokens(v.toString(), ",", {}),
                 {{"com.apple.security.cs.allow-jit",
                   "Runtime Exceptions: Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",
@@ -1788,7 +1791,7 @@ int main(int argc, char* argv[])
             exporter, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
             [](const juce::var& v) {
               return convertIdsToStrings(
-                v,
+                juce::StringArray::fromTokens(v.toString(), ",", {}),
                 {{"com.apple.security.cs.allow-jit",
                   "Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -1011,16 +1011,16 @@ int main(int argc, char* argv[])
               return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
                                         : juce::StringArray{"Fx"};
             }
-            auto vst3_category = juce::StringArray::fromTokens(v.toString(), ",", {});
-            if (vst3_category.contains("Instrument"))
+            auto vst3Category = juce::StringArray::fromTokens(v.toString(), ",", {});
+            if (vst3Category.contains("Instrument"))
             {
-              vst3_category.move(vst3_category.indexOf("Instrument"), 0);
+              vst3Category.move(vst3Category.indexOf("Instrument"), 0);
             }
-            if (vst3_category.contains("Fx"))
+            if (vst3Category.contains("Fx"))
             {
-              vst3_category.move(vst3_category.indexOf("Fx"), 0);
+              vst3Category.move(vst3Category.indexOf("Fx"), 0);
             }
-            return vst3_category;
+            return vst3Category;
           });
       }
 

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -843,7 +843,7 @@ int main(int argc, char* argv[])
 
     convertSettingAsListIfDefined(
       jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
-      [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+      parsePreprocessorDefinitions);
     convertSettingAsListIfDefined(
       jucerProject, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::String& value) {
         return juce::StringArray::fromTokens(value, ";\r\n", {});
@@ -1548,7 +1548,7 @@ int main(int argc, char* argv[])
 
       convertSettingAsListIfDefined(
         exporter, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
-        [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+        parsePreprocessorDefinitions);
       convertSettingAsListIfDefined(
         exporter, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::String& value) {
           return juce::StringArray::fromTokens(value, false);
@@ -2083,7 +2083,7 @@ int main(int argc, char* argv[])
 
         convertSettingAsListIfDefined(
           configuration, "defines", "PREPROCESSOR_DEFINITIONS",
-          [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
+          parsePreprocessorDefinitions);
 
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
@@ -2303,9 +2303,7 @@ int main(int argc, char* argv[])
 
           convertSettingAsListIfDefined(
             configuration, "plistPreprocessorDefinitions",
-            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::String& value) {
-              return parsePreprocessorDefinitions(value);
-            });
+            "PLIST_PREPROCESSOR_DEFINITIONS", parsePreprocessorDefinitions);
 
           convertSettingIfDefined(configuration, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -23,7 +23,6 @@
   #pragma clang diagnostic ignored "-Wcast-align"
   #pragma clang diagnostic ignored "-Wcast-qual"
   #pragma clang diagnostic ignored "-Wdocumentation"
-  #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
   #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
   #pragma clang diagnostic ignored "-Wexit-time-destructors"
   #pragma clang diagnostic ignored "-Wextra-semi"

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -270,9 +270,10 @@ juce::StringArray parsePreprocessorDefinitions(const juce::String& input)
 }
 
 
-const juce::XmlElement* getChildByAttributeRecursively(const juce::XmlElement& parent,
-                                                       const juce::StringRef attributeName,
-                                                       const juce::StringRef attributeValue)
+const juce::XmlElement*
+getChildByAttributeRecursively(const juce::XmlElement& parent,
+                               const juce::StringRef attributeName,
+                               const juce::StringRef attributeValue)
 {
   if (const auto pChild = parent.getChildByAttribute(attributeName, attributeValue))
   {
@@ -490,7 +491,8 @@ int main(int argc, char* argv[])
     };
 
   const auto convertSettingIfDefined =
-    [&convertSetting](const juce::XmlElement& element, const juce::StringRef attributeName,
+    [&convertSetting](const juce::XmlElement& element,
+                      const juce::StringRef attributeName,
                       const juce::String& cmakeKeyword,
                       std::function<juce::String(const juce::String&)> converterFn) {
       if (element.hasAttribute(attributeName))
@@ -500,9 +502,9 @@ int main(int argc, char* argv[])
     };
 
   const auto convertSettingWithDefault =
-    [&convertSetting](const juce::XmlElement& element, const juce::StringRef attributeName,
-                      const juce::String& cmakeKeyword,
-                      const juce::String& defaultValue) {
+    [&convertSetting](
+      const juce::XmlElement& element, const juce::StringRef attributeName,
+      const juce::String& cmakeKeyword, const juce::String& defaultValue) {
       if (!element.hasAttribute(attributeName))
       {
         convertSetting(element, attributeName, cmakeKeyword,
@@ -569,9 +571,10 @@ int main(int argc, char* argv[])
       }
       else
       {
-        convertOnOffSetting(
-          element, attributeName, cmakeKeyword,
-          [](const juce::String& value) -> juce::String { return toBoolLikeVar(value) ? "ON" : "OFF"; });
+        convertOnOffSetting(element, attributeName, cmakeKeyword,
+                            [](const juce::String& value) -> juce::String {
+                              return toBoolLikeVar(value) ? "ON" : "OFF";
+                            });
       }
     };
 
@@ -611,7 +614,8 @@ int main(int argc, char* argv[])
       std::function<juce::StringArray(const juce::String&)> converterFn) {
       if (element.hasAttribute(attributeName))
       {
-        convertSettingAsList(element, attributeName, cmakeKeyword, std::move(converterFn));
+        convertSettingAsList(element, attributeName, cmakeKeyword,
+                             std::move(converterFn));
       }
     };
 
@@ -750,9 +754,10 @@ int main(int argc, char* argv[])
       }
       else
       {
-        convertOnOffSetting(
-          jucerProject, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
-          [&tagLine](const juce::String& value) { return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine; });
+        convertOnOffSetting(jucerProject, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
+                            [&tagLine](const juce::String& value) {
+                              return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine;
+                            });
       }
 
       if (!jucerProject.hasAttribute("displaySplashScreen"))
@@ -761,9 +766,11 @@ int main(int argc, char* argv[])
       }
       else
       {
-        convertOnOffSetting(
-          jucerProject, "displaySplashScreen", "DISPLAY_THE_JUCE_SPLASH_SCREEN",
-          [&tagLine](const juce::String& value) { return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine; });
+        convertOnOffSetting(jucerProject, "displaySplashScreen",
+                            "DISPLAY_THE_JUCE_SPLASH_SCREEN",
+                            [&tagLine](const juce::String& value) {
+                              return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine;
+                            });
       }
 
       convertSettingIfDefined(jucerProject, "splashScreenColour", "SPLASH_SCREEN_COLOUR",
@@ -852,9 +859,8 @@ int main(int argc, char* argv[])
       wLn("  ", "CXX_LANGUAGE_STANDARD", " \"C++11\"");
     }
 
-    convertSettingAsListIfDefined(
-      jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
-      parsePreprocessorDefinitions);
+    convertSettingAsListIfDefined(jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
+                                  parsePreprocessorDefinitions);
     convertSettingAsListIfDefined(
       jucerProject, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::String& value) {
         return juce::StringArray::fromTokens(value, ";\r\n", {});
@@ -973,9 +979,10 @@ int main(int argc, char* argv[])
       const auto pluginCharacteristics = juce::StringArray::fromTokens(
         jucerProject.getStringAttribute("pluginCharacteristicsValue"), ",", {});
 
-      const auto isSynthAudioPlugin = jucerVersionAsTuple >= Version{5, 3, 1}
-                                        ? pluginCharacteristics.contains("pluginIsSynth")
-                                        : toBoolLikeVar(jucerProject.getStringAttribute("pluginIsSynth"));
+      const auto isSynthAudioPlugin =
+        jucerVersionAsTuple >= Version{5, 3, 1}
+          ? pluginCharacteristics.contains("pluginIsSynth")
+          : toBoolLikeVar(jucerProject.getStringAttribute("pluginIsSynth"));
 
       if (jucerVersionAsTuple < Version{5, 3, 1})
       {
@@ -1073,12 +1080,12 @@ int main(int argc, char* argv[])
       {
         if (!jucerProject.hasAttribute("pluginVST3Category"))
         {
-          convertSettingAsList(
-            jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [isSynthAudioPlugin](const juce::String&) {
-              return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
-                                        : juce::StringArray{"Fx"};
-            });
+          convertSettingAsList(jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
+                               [isSynthAudioPlugin](const juce::String&) {
+                                 return isSynthAudioPlugin
+                                          ? juce::StringArray{"Instrument", "Synth"}
+                                          : juce::StringArray{"Fx"};
+                               });
         }
         else
         {
@@ -1103,12 +1110,12 @@ int main(int argc, char* argv[])
       {
         if (!jucerProject.hasAttribute("pluginRTASCategory"))
         {
-          convertSettingAsList(
-            jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-            [isSynthAudioPlugin](const juce::String&) {
-              return juce::StringArray{isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
-                                                          : "ePlugInCategory_None"};
-            });
+          convertSettingAsList(jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
+                               [isSynthAudioPlugin](const juce::String&) {
+                                 return juce::StringArray{
+                                   isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
+                                                      : "ePlugInCategory_None"};
+                               });
         }
         else
         {
@@ -1324,7 +1331,8 @@ int main(int argc, char* argv[])
       const auto& module = *pModule;
       const auto& moduleName = module.getStringAttribute("id");
 
-      const auto useGlobalPath = toBoolLikeVar(module.getStringAttribute("useGlobalPath"));
+      const auto useGlobalPath =
+        toBoolLikeVar(module.getStringAttribute("useGlobalPath"));
       const auto isJuceModule = moduleName.startsWith("juce_");
 
       if (useGlobalPath)
@@ -1523,8 +1531,7 @@ int main(int argc, char* argv[])
 
         if (needsTargetFolder)
         {
-          wLn("  TARGET_PROJECT_FOLDER \"",
-              exporter.getStringAttribute("targetFolder"),
+          wLn("  TARGET_PROJECT_FOLDER \"", exporter.getStringAttribute("targetFolder"),
               "\" # only used by PREBUILD_COMMAND and POSTBUILD_COMMAND");
         }
       }
@@ -1538,9 +1545,10 @@ int main(int argc, char* argv[])
         != nullptr;
 
       const auto hasVst2Interface = jucerVersionAsTuple > Version{4, 2, 3};
-      const auto isVstAudioPlugin = isAudioPlugin
-                                    && (pluginFormats.contains("buildVST")
-                                        || toBoolLikeVar(jucerProject.getStringAttribute("buildVST")));
+      const auto isVstAudioPlugin =
+        isAudioPlugin
+        && (pluginFormats.contains("buildVST")
+            || toBoolLikeVar(jucerProject.getStringAttribute("buildVST")));
       const auto& pluginHostVstOption = safeGetChildByName(jucerProject, "JUCEOPTIONS")
                                           .getStringAttribute("JUCE_PLUGINHOST_VST");
       const auto isVstPluginHost =
@@ -1560,9 +1568,10 @@ int main(int argc, char* argv[])
       }
 
       const auto supportsVst3 = exporterType == "XCODE_MAC" || isVSExporter;
-      const auto isVst3AudioPlugin = isAudioPlugin
-                                     && (pluginFormats.contains("buildVST3")
-                                         || toBoolLikeVar(jucerProject.getStringAttribute("buildVST3")));
+      const auto isVst3AudioPlugin =
+        isAudioPlugin
+        && (pluginFormats.contains("buildVST3")
+            || toBoolLikeVar(jucerProject.getStringAttribute("buildVST3")));
       const auto& pluginHostVst3Option = safeGetChildByName(jucerProject, "JUCEOPTIONS")
                                            .getStringAttribute("JUCE_PLUGINHOST_VST3");
       const auto isVst3PluginHost =
@@ -1591,13 +1600,14 @@ int main(int argc, char* argv[])
         }
       }
 
-      convertSettingAsListIfDefined(
-        exporter, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
-        parsePreprocessorDefinitions);
-      convertSettingAsListIfDefined(
-        exporter, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::String& value) {
-          return juce::StringArray::fromTokens(value, false);
-        });
+      convertSettingAsListIfDefined(exporter, "extraDefs",
+                                    "EXTRA_PREPROCESSOR_DEFINITIONS",
+                                    parsePreprocessorDefinitions);
+      convertSettingAsListIfDefined(exporter, "extraCompilerFlags",
+                                    "EXTRA_COMPILER_FLAGS",
+                                    [](const juce::String& value) {
+                                      return juce::StringArray::fromTokens(value, false);
+                                    });
 
       const auto compilerFlagSchemesArray = juce::StringArray::fromTokens(
         jucerProject.getStringAttribute("compilerFlagSchemes"), ",", {});
@@ -1614,17 +1624,18 @@ int main(int argc, char* argv[])
                                 {});
       }
 
-      convertSettingAsListIfDefined(
-        exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::String& value) {
-          return juce::StringArray::fromTokens(value, false);
-        });
+      convertSettingAsListIfDefined(exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS",
+                                    [](const juce::String& value) {
+                                      return juce::StringArray::fromTokens(value, false);
+                                    });
       convertSettingAsListIfDefined(exporter, "externalLibraries",
                                     "EXTERNAL_LIBRARIES_TO_LINK", {});
 
       convertOnOffSettingIfDefined(exporter, "enableGNUExtensions",
                                    "GNU_COMPILER_EXTENSIONS", {});
 
-      const auto convertIcon = [&safeGetChildByName, &jucerProject](const juce::String& fileId) -> juce::String {
+      const auto convertIcon =
+        [&safeGetChildByName, &jucerProject](const juce::String& fileId) -> juce::String {
         if (fileId.isNotEmpty())
         {
           if (const auto pFile = getChildByAttributeRecursively(
@@ -1723,7 +1734,8 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(exporter, "appSandboxInheritance",
                                      "APP_SANDBOX_INHERITANCE", {});
         convertSettingAsListIfDefined(
-          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::String& value) {
+          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS",
+          [](const juce::String& value) {
             return convertIdsToStrings(
               juce::StringArray::fromTokens(value, ",", {}),
               {{"com.apple.security.network.server",
@@ -1895,7 +1907,8 @@ int main(int argc, char* argv[])
         convertSettingIfDefined(exporter, "customPList", "CUSTOM_PLIST", {});
         convertOnOffSettingIfDefined(exporter, "PListPreprocess", "PLIST_PREPROCESS", {});
         convertOnOffSettingIfDefined(exporter, "pListPreprocess", "PLIST_PREPROCESS", {});
-        const auto convertPrefixHeader = [&jucerFile, &exporter](const juce::String& value) {
+        const auto convertPrefixHeader = [&jucerFile,
+                                          &exporter](const juce::String& value) {
           if (value.isEmpty())
             return juce::String{};
 
@@ -2030,7 +2043,8 @@ int main(int argc, char* argv[])
                                 });
 
         convertSettingAsListIfDefined(
-          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::String& value) {
+          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES",
+          [](const juce::String& value) {
             return juce::StringArray::fromTokens(value, " ", "\"'");
           });
       }
@@ -2045,16 +2059,17 @@ int main(int argc, char* argv[])
           {"0x0A00", "Windows 10"},
         };
 
-        convertSettingIfDefined(exporter, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
-                                [&windowsTargets](const juce::String& value) -> juce::String {
-                                  auto search = windowsTargets.find(value);
-                                  if (search != windowsTargets.end())
-                                  {
-                                    return search->second;
-                                  }
+        convertSettingIfDefined(
+          exporter, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
+          [&windowsTargets](const juce::String& value) -> juce::String {
+            auto search = windowsTargets.find(value);
+            if (search != windowsTargets.end())
+            {
+              return search->second;
+            }
 
-                                  return {};
-                                });
+            return {};
+          });
       }
 
       writeUserNotes(wLn, exporter);
@@ -2130,18 +2145,19 @@ int main(int argc, char* argv[])
         convertSettingAsListIfDefined(configuration, "libraryPath",
                                       "EXTRA_LIBRARY_SEARCH_PATHS", convertSearchPaths);
 
-        convertSettingAsListIfDefined(
-          configuration, "defines", "PREPROCESSOR_DEFINITIONS",
-          parsePreprocessorDefinitions);
+        convertSettingAsListIfDefined(configuration, "defines",
+                                      "PREPROCESSOR_DEFINITIONS",
+                                      parsePreprocessorDefinitions);
 
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
 
-        if (!configuration.hasAttribute("linkTimeOptimisation") && isVSExporter && !isDebug
-            && jucerVersionAsTuple >= Version{5, 2, 0})
+        if (!configuration.hasAttribute("linkTimeOptimisation") && isVSExporter
+            && !isDebug && jucerVersionAsTuple >= Version{5, 2, 0})
         {
           convertOnOffSettingIfDefined(configuration, "wholeProgramOptimisation",
-                                       "LINK_TIME_OPTIMISATION", [](const juce::String& value) {
+                                       "LINK_TIME_OPTIMISATION",
+                                       [](const juce::String& value) {
                                          if (value.getIntValue() == 0)
                                            return "ON";
 
@@ -2185,41 +2201,42 @@ int main(int argc, char* argv[])
                                   });
         }
 
-        convertSettingIfDefined(configuration, "optimisation", "OPTIMISATION",
-                                [&isVSExporter](const juce::String& value) -> juce::String {
-                                  if (isVSExporter)
-                                  {
-                                    switch (value.getIntValue())
-                                    {
-                                    case 1:
-                                      return "No optimisation";
-                                    case 2:
-                                      return "Minimise size";
-                                    case 3:
-                                      return "Maximise speed";
-                                    }
+        convertSettingIfDefined(
+          configuration, "optimisation", "OPTIMISATION",
+          [&isVSExporter](const juce::String& value) -> juce::String {
+            if (isVSExporter)
+            {
+              switch (value.getIntValue())
+              {
+              case 1:
+                return "No optimisation";
+              case 2:
+                return "Minimise size";
+              case 3:
+                return "Maximise speed";
+              }
 
-                                    return {};
-                                  }
+              return {};
+            }
 
-                                  switch (value.getIntValue())
-                                  {
-                                  case 1:
-                                    return "-O0 (no optimisation)";
-                                  case 2:
-                                    return "-Os (minimise code size)";
-                                  case 3:
-                                    return "-O3 (fastest with safe optimisations)";
-                                  case 4:
-                                    return "-O1 (fast)";
-                                  case 5:
-                                    return "-O2 (faster)";
-                                  case 6:
-                                    return "-Ofast (uses aggressive optimisations)";
-                                  }
+            switch (value.getIntValue())
+            {
+            case 1:
+              return "-O0 (no optimisation)";
+            case 2:
+              return "-Os (minimise code size)";
+            case 3:
+              return "-O3 (fastest with safe optimisations)";
+            case 4:
+              return "-O1 (fast)";
+            case 5:
+              return "-O2 (faster)";
+            case 6:
+              return "-Ofast (uses aggressive optimisations)";
+            }
 
-                                  return {};
-                                });
+            return {};
+          });
 
         if (isXcodeExporter)
         {
@@ -2350,9 +2367,9 @@ int main(int argc, char* argv[])
               return customFlags;
             });
 
-          convertSettingAsListIfDefined(
-            configuration, "plistPreprocessorDefinitions",
-            "PLIST_PREPROCESSOR_DEFINITIONS", parsePreprocessorDefinitions);
+          convertSettingAsListIfDefined(configuration, "plistPreprocessorDefinitions",
+                                        "PLIST_PREPROCESSOR_DEFINITIONS",
+                                        parsePreprocessorDefinitions);
 
           convertSettingIfDefined(configuration, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",
@@ -2562,7 +2579,8 @@ int main(int argc, char* argv[])
                                   });
         }
 
-        const auto codeBlocksArchitecture = [](const juce::String& value) -> juce::String {
+        const auto codeBlocksArchitecture =
+          [](const juce::String& value) -> juce::String {
           if (value == "-m32")
             return "32-bit (-m32)";
 

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -148,6 +148,15 @@ void printError(const juce::String& error)
 }
 
 
+// Matches juce::var::VariantType_String::toBool. This means that `toBoolLikeVar(s)` and
+// `bool{juce::var{s}}` are equivalent.
+bool toBoolLikeVar(const juce::String& s)
+{
+  return s.getIntValue() != 0 || s.trim().equalsIgnoreCase("true")
+         || s.trim().equalsIgnoreCase("yes");
+}
+
+
 juce::String makeValidIdentifier(juce::String s)
 {
   if (s.isEmpty())
@@ -509,7 +518,7 @@ int main(int argc, char* argv[])
         else
         {
           converterFn = [](const juce::var& v) -> juce::String {
-            return bool{v} ? "ON" : "OFF";
+            return toBoolLikeVar(v.toString()) ? "ON" : "OFF";
           };
         }
       }
@@ -552,7 +561,7 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           valueTree, property, cmakeKeyword,
-          [](const juce::var& v) -> juce::String { return bool{v} ? "ON" : "OFF"; });
+          [](const juce::var& v) -> juce::String { return toBoolLikeVar(v.toString()) ? "ON" : "OFF"; });
       }
     };
 
@@ -733,7 +742,7 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           jucerProject, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
-          [&tagLine](const juce::var& v) { return (bool{v} ? "ON" : "OFF") + tagLine; });
+          [&tagLine](const juce::var& v) { return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine; });
       }
 
       if (!jucerProject.hasProperty("displaySplashScreen"))
@@ -744,7 +753,7 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           jucerProject, "displaySplashScreen", "DISPLAY_THE_JUCE_SPLASH_SCREEN",
-          [&tagLine](const juce::var& v) { return (bool{v} ? "ON" : "OFF") + tagLine; });
+          [&tagLine](const juce::var& v) { return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine; });
       }
 
       convertSettingIfDefined(jucerProject, "splashScreenColour", "SPLASH_SCREEN_COLOUR",
@@ -956,7 +965,7 @@ int main(int argc, char* argv[])
 
       const auto isSynthAudioPlugin = jucerVersionAsTuple >= Version{5, 3, 1}
                                         ? pluginCharacteristics.contains("pluginIsSynth")
-                                        : bool{jucerProject.getProperty("pluginIsSynth")};
+                                        : toBoolLikeVar(jucerProject.getProperty("pluginIsSynth").toString());
 
       if (jucerVersionAsTuple < Version{5, 3, 1})
       {
@@ -1284,7 +1293,7 @@ int main(int argc, char* argv[])
       const auto module = modules.getChild(i);
       const auto moduleName = module.getProperty("id").toString();
 
-      const auto useGlobalPath = bool{module.getProperty("useGlobalPath")};
+      const auto useGlobalPath = toBoolLikeVar(module.getProperty("useGlobalPath").toString());
       const auto isJuceModule = moduleName.startsWith("juce_");
 
       if (useGlobalPath)
@@ -1484,7 +1493,7 @@ int main(int argc, char* argv[])
       const auto hasVst2Interface = jucerVersionAsTuple > Version{4, 2, 3};
       const auto isVstAudioPlugin = isAudioPlugin
                                     && (pluginFormats.contains("buildVST")
-                                        || bool{jucerProject.getProperty("buildVST")});
+                                        || toBoolLikeVar(jucerProject.getProperty("buildVST").toString()));
       const auto pluginHostVstOption = jucerProject.getChildWithName("JUCEOPTIONS")
                                          .getProperty("JUCE_PLUGINHOST_VST")
                                          .toString();
@@ -1507,7 +1516,7 @@ int main(int argc, char* argv[])
       const auto supportsVst3 = exporterType == "XCODE_MAC" || isVSExporter;
       const auto isVst3AudioPlugin = isAudioPlugin
                                      && (pluginFormats.contains("buildVST3")
-                                         || bool{jucerProject.getProperty("buildVST3")});
+                                         || toBoolLikeVar(jucerProject.getProperty("buildVST3").toString()));
       const auto pluginHostVst3Option = jucerProject.getChildWithName("JUCEOPTIONS")
                                           .getProperty("JUCE_PLUGINHOST_VST3")
                                           .toString();
@@ -1525,13 +1534,13 @@ int main(int argc, char* argv[])
       if (supportsAaxRtas && isAudioPlugin)
       {
         if (pluginFormats.contains("buildAAX")
-            || bool{jucerProject.getProperty("buildAAX")})
+            || toBoolLikeVar(jucerProject.getProperty("buildAAX").toString()))
         {
           convertSetting(exporter, "aaxFolder", "AAX_SDK_FOLDER", {});
         }
 
         if (pluginFormats.contains("buildRTAS")
-            || bool{jucerProject.getProperty("buildRTAS")})
+            || toBoolLikeVar(jucerProject.getProperty("buildRTAS").toString()))
         {
           convertSetting(exporter, "rtasFolder", "RTAS_SDK_FOLDER", {});
         }
@@ -2034,7 +2043,7 @@ int main(int argc, char* argv[])
         wLn("  \"", exporterName, "\"");
         wLn("  NAME \"", configuration.getProperty("name").toString(), "\"");
 
-        const auto isDebug = bool{configuration.getProperty("isDebug")};
+        const auto isDebug = toBoolLikeVar(configuration.getProperty("isDebug").toString());
         wLn("  DEBUG_MODE ", (isDebug ? "ON" : "OFF"));
 
         convertSettingIfDefined(configuration, "targetName", "BINARY_NAME", {});

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -459,13 +459,13 @@ int main(int argc, char* argv[])
   const auto convertSetting =
     [&wLn](const juce::ValueTree& valueTree, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::String(const juce::var&)> converterFn) {
+           std::function<juce::String(const juce::String&)> converterFn) {
       if (!converterFn)
       {
-        converterFn = [](const juce::var& v) { return v.toString(); };
+        converterFn = [](const juce::String& value) { return value; };
       }
 
-      const auto value = converterFn(valueTree.getProperty(property));
+      const auto value = converterFn(valueTree.getProperty(property).toString());
 
       if (value.isEmpty())
       {
@@ -481,7 +481,7 @@ int main(int argc, char* argv[])
   const auto convertSettingIfDefined =
     [&convertSetting](const juce::ValueTree& valueTree, const juce::Identifier& property,
                       const juce::String& cmakeKeyword,
-                      std::function<juce::String(const juce::var&)> converterFn) {
+                      std::function<juce::String(const juce::String&)> converterFn) {
       if (valueTree.hasProperty(property))
       {
         convertSetting(valueTree, property, cmakeKeyword, std::move(converterFn));
@@ -495,34 +495,34 @@ int main(int argc, char* argv[])
       if (!valueTree.hasProperty(property))
       {
         convertSetting(valueTree, property, cmakeKeyword,
-                       [&defaultValue](const juce::var&) { return defaultValue; });
+                       [&defaultValue](const juce::String&) { return defaultValue; });
       }
       else
       {
         convertSetting(valueTree, property, cmakeKeyword,
-                       [](const juce::var& v) { return v.toString(); });
+                       [](const juce::String& value) { return value; });
       }
     };
 
   const auto convertOnOffSetting =
     [&wLn](const juce::ValueTree& valueTree, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::String(const juce::var&)> converterFn) {
+           std::function<juce::String(const juce::String&)> converterFn) {
       if (!converterFn)
       {
         if (!valueTree.hasProperty(property))
         {
-          converterFn = [](const juce::var&) -> juce::String { return {}; };
+          converterFn = [](const juce::String&) -> juce::String { return {}; };
         }
         else
         {
-          converterFn = [](const juce::var& v) -> juce::String {
-            return toBoolLikeVar(v.toString()) ? "ON" : "OFF";
+          converterFn = [](const juce::String& value) -> juce::String {
+            return toBoolLikeVar(value) ? "ON" : "OFF";
           };
         }
       }
 
-      const auto value = converterFn(valueTree.getProperty(property));
+      const auto value = converterFn(valueTree.getProperty(property).toString());
 
       if (value.isEmpty())
       {
@@ -538,7 +538,7 @@ int main(int argc, char* argv[])
     [&convertOnOffSetting](const juce::ValueTree& valueTree,
                            const juce::Identifier& property,
                            const juce::String& cmakeKeyword,
-                           std::function<juce::String(const juce::var&)> converterFn) {
+                           std::function<juce::String(const juce::String&)> converterFn) {
       if (valueTree.hasProperty(property))
       {
         convertOnOffSetting(valueTree, property, cmakeKeyword, std::move(converterFn));
@@ -552,7 +552,7 @@ int main(int argc, char* argv[])
       if (!valueTree.hasProperty(property))
       {
         convertOnOffSetting(valueTree, property, cmakeKeyword,
-                            [defaultValue](const juce::var&) -> juce::String {
+                            [defaultValue](const juce::String&) -> juce::String {
                               return defaultValue ? "ON" : "OFF";
                             });
       }
@@ -560,22 +560,22 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           valueTree, property, cmakeKeyword,
-          [](const juce::var& v) -> juce::String { return toBoolLikeVar(v.toString()) ? "ON" : "OFF"; });
+          [](const juce::String& value) -> juce::String { return toBoolLikeVar(value) ? "ON" : "OFF"; });
       }
     };
 
   const auto convertSettingAsList =
     [&wLn](const juce::ValueTree& valueTree, const juce::Identifier& property,
            const juce::String& cmakeKeyword,
-           std::function<juce::StringArray(const juce::var&)> converterFn) {
+           std::function<juce::StringArray(const juce::String&)> converterFn) {
       if (!converterFn)
       {
-        converterFn = [](const juce::var& v) {
-          return juce::StringArray::fromLines(v.toString());
+        converterFn = [](const juce::String& value) {
+          return juce::StringArray::fromLines(value);
         };
       }
 
-      auto value = converterFn(valueTree.getProperty(property));
+      auto value = converterFn(valueTree.getProperty(property).toString());
       value.removeEmptyStrings();
 
       if (value.isEmpty())
@@ -597,7 +597,7 @@ int main(int argc, char* argv[])
     [&convertSettingAsList](
       const juce::ValueTree& valueTree, const juce::Identifier& property,
       const juce::String& cmakeKeyword,
-      std::function<juce::StringArray(const juce::var&)> converterFn) {
+      std::function<juce::StringArray(const juce::String&)> converterFn) {
       if (valueTree.hasProperty(property))
       {
         convertSettingAsList(valueTree, property, cmakeKeyword, std::move(converterFn));
@@ -741,7 +741,7 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           jucerProject, "reportAppUsage", "REPORT_JUCE_APP_USAGE",
-          [&tagLine](const juce::var& v) { return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine; });
+          [&tagLine](const juce::String& value) { return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine; });
       }
 
       if (!jucerProject.hasProperty("displaySplashScreen"))
@@ -752,7 +752,7 @@ int main(int argc, char* argv[])
       {
         convertOnOffSetting(
           jucerProject, "displaySplashScreen", "DISPLAY_THE_JUCE_SPLASH_SCREEN",
-          [&tagLine](const juce::var& v) { return (toBoolLikeVar(v.toString()) ? "ON" : "OFF") + tagLine; });
+          [&tagLine](const juce::String& value) { return (toBoolLikeVar(value) ? "ON" : "OFF") + tagLine; });
       }
 
       convertSettingIfDefined(jucerProject, "splashScreenColour", "SPLASH_SCREEN_COLOUR",
@@ -794,11 +794,11 @@ int main(int argc, char* argv[])
                               defaultBundleIdentifier);
 
     convertSettingIfDefined(jucerProject, "maxBinaryFileSize", "BINARYDATACPP_SIZE_LIMIT",
-                            [](const juce::var& v) -> juce::String {
-                              if (v.toString().isEmpty())
+                            [](const juce::String& value) -> juce::String {
+                              if (value.isEmpty())
                                 return "Default";
                               return juce::File::descriptionOfSizeInBytes(
-                                v.toString().getIntValue());
+                                value.getIntValue());
                             });
     if (jucerProject.hasProperty("includeBinaryInJuceHeader"))
     {
@@ -816,9 +816,7 @@ int main(int argc, char* argv[])
     if (jucerProject.hasProperty("cppLanguageStandard"))
     {
       convertSetting(jucerProject, "cppLanguageStandard", "CXX_LANGUAGE_STANDARD",
-                     [](const juce::var& v) -> juce::String {
-                       const auto value = v.toString();
-
+                     [](const juce::String& value) -> juce::String {
                        if (value == "11")
                          return "C++11";
 
@@ -845,10 +843,10 @@ int main(int argc, char* argv[])
 
     convertSettingAsListIfDefined(
       jucerProject, "defines", "PREPROCESSOR_DEFINITIONS",
-      [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+      [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
     convertSettingAsListIfDefined(
-      jucerProject, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::var& v) {
-        return juce::StringArray::fromTokens(v.toString(), ";\r\n", {});
+      jucerProject, "headerPath", "HEADER_SEARCH_PATHS", [](const juce::String& value) {
+        return juce::StringArray::fromTokens(value, ";\r\n", {});
       });
 
     convertSettingIfDefined(jucerProject, "postExportShellCommandPosix",
@@ -874,7 +872,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginFormats", "PLUGIN_FORMATS",
-            [&vstIsLegacy](const juce::var&) {
+            [&vstIsLegacy](const juce::String&) {
               return juce::StringArray{vstIsLegacy ? "VST3" : "VST", "AU", "Standalone"};
             });
         }
@@ -882,10 +880,10 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginFormats", "PLUGIN_FORMATS",
-            [&jucerVersionAsTuple, &vstIsLegacy](const juce::var& v) {
+            [&jucerVersionAsTuple, &vstIsLegacy](const juce::String& value) {
               const auto supportsUnity = jucerVersionAsTuple >= Version{5, 3, 2};
               return convertIdsToStrings(
-                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                juce::StringArray::fromTokens(value, ",", {}),
                 {{vstIsLegacy ? "" : "buildVST", vstIsLegacy ? "" : "VST"},
                  {"buildVST3", "VST3"},
                  {"buildAU", "AU"},
@@ -907,9 +905,9 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginCharacteristicsValue", "PLUGIN_CHARACTERISTICS",
-            [](const juce::var& v) {
+            [](const juce::String& value) {
               return convertIdsToStrings(
-                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                juce::StringArray::fromTokens(value, ",", {}),
                 {{"pluginIsSynth", "Plugin is a Synth"},
                  {"pluginWantsMidiIn", "Plugin MIDI Input"},
                  {"pluginProducesMidiOut", "Plugin MIDI Output"},
@@ -994,7 +992,7 @@ int main(int argc, char* argv[])
         if (!jucerProject.hasProperty("pluginAUMainType"))
         {
           convertSetting(jucerProject, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
-                         [&pluginCharacteristics](const juce::var&) -> juce::String {
+                         [&pluginCharacteristics](const juce::String&) -> juce::String {
                            if (pluginCharacteristics.contains("pluginIsMidiEffectPlugin"))
                              return "kAudioUnitType_MIDIProcessor"; // 'aumi'
 
@@ -1010,8 +1008,7 @@ int main(int argc, char* argv[])
         else
         {
           convertSetting(jucerProject, "pluginAUMainType", "PLUGIN_AU_MAIN_TYPE",
-                         [](const juce::var& v) -> juce::String {
-                           const auto value = v.toString();
+                         [](const juce::String& value) -> juce::String {
                            // clang-format off
                            if (value == "'aufx'") return "kAudioUnitType_Effect";
                            if (value == "'aufc'") return "kAudioUnitType_FormatConverter";
@@ -1067,7 +1064,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) {
+            [isSynthAudioPlugin](const juce::String&) {
               return isSynthAudioPlugin ? juce::StringArray{"Instrument", "Synth"}
                                         : juce::StringArray{"Fx"};
             });
@@ -1076,8 +1073,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginVST3Category", "PLUGIN_VST3_CATEGORY",
-            [](const juce::var& v) {
-              auto vst3Category = juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              auto vst3Category = juce::StringArray::fromTokens(value, ",", {});
               if (vst3Category.contains("Instrument"))
               {
                 vst3Category.move(vst3Category.indexOf("Instrument"), 0);
@@ -1097,7 +1094,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) {
+            [isSynthAudioPlugin](const juce::String&) {
               return juce::StringArray{isSynthAudioPlugin ? "ePlugInCategory_SWGenerators"
                                                           : "ePlugInCategory_None"};
             });
@@ -1105,9 +1102,9 @@ int main(int argc, char* argv[])
         else
         {
           convertSettingAsList(jucerProject, "pluginRTASCategory", "PLUGIN_RTAS_CATEGORY",
-                               [](const juce::var& v) {
+                               [](const juce::String& value) {
                                  return convertIdsToStrings(
-                                   juce::StringArray::fromTokens(v.toString(), ",", {}),
+                                   juce::StringArray::fromTokens(value, ",", {}),
                                    {{"0", "ePlugInCategory_None"},
                                     {"1", "ePlugInCategory_EQ"},
                                     {"2", "ePlugInCategory_Dynamics"},
@@ -1130,7 +1127,7 @@ int main(int argc, char* argv[])
         {
           convertSettingAsList(
             jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-            [isSynthAudioPlugin](const juce::var&) -> juce::StringArray {
+            [isSynthAudioPlugin](const juce::String&) -> juce::StringArray {
               return juce::StringArray{isSynthAudioPlugin
                                          ? "AAX_ePlugInCategory_SWGenerators"
                                          : "AAX_ePlugInCategory_None"};
@@ -1139,9 +1136,9 @@ int main(int argc, char* argv[])
         else
         {
           convertSettingAsList(jucerProject, "pluginAAXCategory", "PLUGIN_AAX_CATEGORY",
-                               [](const juce::var& v) -> juce::StringArray {
+                               [](const juce::String& value) -> juce::StringArray {
                                  return convertIdsToStrings(
-                                   juce::StringArray::fromTokens(v.toString(), ",", {}),
+                                   juce::StringArray::fromTokens(value, ",", {}),
                                    {{"0", "AAX_ePlugInCategory_None"},
                                     {"1", "AAX_ePlugInCategory_EQ"},
                                     {"2", "AAX_ePlugInCategory_Dynamics"},
@@ -1551,10 +1548,10 @@ int main(int argc, char* argv[])
 
       convertSettingAsListIfDefined(
         exporter, "extraDefs", "EXTRA_PREPROCESSOR_DEFINITIONS",
-        [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+        [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
       convertSettingAsListIfDefined(
-        exporter, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::var& v) {
-          return juce::StringArray::fromTokens(v.toString(), false);
+        exporter, "extraCompilerFlags", "EXTRA_COMPILER_FLAGS", [](const juce::String& value) {
+          return juce::StringArray::fromTokens(value, false);
         });
 
       const auto compilerFlagSchemesArray = juce::StringArray::fromTokens(
@@ -1573,8 +1570,8 @@ int main(int argc, char* argv[])
       }
 
       convertSettingAsListIfDefined(
-        exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::var& v) {
-          return juce::StringArray::fromTokens(v.toString(), false);
+        exporter, "extraLinkerFlags", "EXTRA_LINKER_FLAGS", [](const juce::String& value) {
+          return juce::StringArray::fromTokens(value, false);
         });
       convertSettingAsListIfDefined(exporter, "externalLibraries",
                                     "EXTERNAL_LIBRARIES_TO_LINK", {});
@@ -1582,9 +1579,7 @@ int main(int argc, char* argv[])
       convertOnOffSettingIfDefined(exporter, "enableGNUExtensions",
                                    "GNU_COMPILER_EXTENSIONS", {});
 
-      const auto convertIcon = [&jucerProject](const juce::var& v) -> juce::String {
-        const auto fileId = v.toString();
-
+      const auto convertIcon = [&jucerProject](const juce::String& fileId) -> juce::String {
         if (fileId.isNotEmpty())
         {
           const auto file = getChildWithPropertyRecursively(
@@ -1614,8 +1609,8 @@ int main(int argc, char* argv[])
       {
         convertSettingAsListIfDefined(
           exporter, "customXcodeResourceFolders", "CUSTOM_XCODE_RESOURCE_FOLDERS",
-          [](const juce::var& v) {
-            auto folders = juce::StringArray::fromLines(v.toString());
+          [](const juce::String& value) {
+            auto folders = juce::StringArray::fromLines(value);
             folders.trim();
             folders.removeEmptyStrings();
             return folders;
@@ -1632,9 +1627,7 @@ int main(int argc, char* argv[])
       if (exporterType == "XCODE_IPHONE")
       {
         convertSettingIfDefined(exporter, "iosDeviceFamily", "DEVICE_FAMILY",
-                                [](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [](const juce::String& value) -> juce::String {
                                   if (value == "1")
                                     return "iPhone";
 
@@ -1647,9 +1640,7 @@ int main(int argc, char* argv[])
                                   return value;
                                 });
 
-        const auto screenOrientationFn = [](const juce::var& v) -> juce::String {
-          const auto value = v.toString();
-
+        const auto screenOrientationFn = [](const juce::String& value) -> juce::String {
           if (value == "portraitlandscape")
             return "Portrait and Landscape";
 
@@ -1680,8 +1671,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporter, "documentExtensions", "DOCUMENT_FILE_EXTENSIONS",
-            [](const juce::var& v) {
-              return juce::StringArray::fromTokens(v.toString(), ",", {});
+            [](const juce::String& value) {
+              return juce::StringArray::fromTokens(value, ",", {});
             });
         }
 
@@ -1689,9 +1680,9 @@ int main(int argc, char* argv[])
         convertOnOffSettingIfDefined(exporter, "appSandboxInheritance",
                                      "APP_SANDBOX_INHERITANCE", {});
         convertSettingAsListIfDefined(
-          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::var& v) {
+          exporter, "appSandboxOptions", "APP_SANDBOX_OPTIONS", [](const juce::String& value) {
             return convertIdsToStrings(
-              juce::StringArray::fromTokens(v.toString(), ",", {}),
+              juce::StringArray::fromTokens(value, ",", {}),
               {{"com.apple.security.network.server",
                 "Network: Incoming Connections (Server)"},
                {"com.apple.security.network.client",
@@ -1756,9 +1747,9 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporter, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
-            [](const juce::var& v) {
+            [](const juce::String& value) {
               return convertIdsToStrings(
-                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                juce::StringArray::fromTokens(value, ",", {}),
                 {{"com.apple.security.cs.allow-jit",
                   "Runtime Exceptions: Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",
@@ -1789,9 +1780,9 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             exporter, "hardenedRuntimeOptions", "HARDENED_RUNTIME_OPTIONS",
-            [](const juce::var& v) {
+            [](const juce::String& value) {
               return convertIdsToStrings(
-                juce::StringArray::fromTokens(v.toString(), ",", {}),
+                juce::StringArray::fromTokens(value, ",", {}),
                 {{"com.apple.security.cs.allow-jit",
                   "Allow Execution of JIT-compiled Code"},
                  {"com.apple.security.cs.allow-unsigned-executable-memory",
@@ -1861,9 +1852,7 @@ int main(int argc, char* argv[])
         convertSettingIfDefined(exporter, "customPList", "CUSTOM_PLIST", {});
         convertOnOffSettingIfDefined(exporter, "PListPreprocess", "PLIST_PREPROCESS", {});
         convertOnOffSettingIfDefined(exporter, "pListPreprocess", "PLIST_PREPROCESS", {});
-        const auto convertPrefixHeader = [&jucerFile, &exporter](const juce::var& v) {
-          const auto value = v.toString();
-
+        const auto convertPrefixHeader = [&jucerFile, &exporter](const juce::String& value) {
           if (value.isEmpty())
             return juce::String{};
 
@@ -1882,8 +1871,8 @@ int main(int argc, char* argv[])
           exporter, "extraFrameworks",
           jucerVersionAsTuple > Version{5, 3, 2} ? "EXTRA_SYSTEM_FRAMEWORKS"
                                                  : "EXTRA_FRAMEWORKS",
-          [](const juce::var& v) {
-            auto frameworks = juce::StringArray::fromTokens(v.toString(), ",;", "\"'");
+          [](const juce::String& value) {
+            auto frameworks = juce::StringArray::fromTokens(value, ",;", "\"'");
             frameworks.trim();
             return frameworks;
           });
@@ -1907,8 +1896,8 @@ int main(int argc, char* argv[])
       if (exporterType == "XCODE_IPHONE")
       {
         convertSettingAsListIfDefined(
-          exporter, "iosAppGroupsId", "APP_GROUP_ID", [](const juce::var& v) {
-            auto groups = juce::StringArray::fromTokens(v.toString(), ";", {});
+          exporter, "iosAppGroupsId", "APP_GROUP_ID", [](const juce::String& value) {
+            auto groups = juce::StringArray::fromTokens(value, ";", {});
             groups.trim();
             return groups;
           });
@@ -1940,9 +1929,7 @@ int main(int argc, char* argv[])
 
         convertSettingIfDefined(
           exporter, "IPPLibrary", "USE_IPP_LIBRARY",
-          [&jucerVersionAsTuple](const juce::var& v) -> juce::String {
-            const auto value = v.toString();
-
+          [&jucerVersionAsTuple](const juce::String& value) -> juce::String {
             if (value.isEmpty())
               return "No";
 
@@ -1971,9 +1958,7 @@ int main(int argc, char* argv[])
         if (exporterType == "VS2017")
         {
           convertSettingIfDefined(exporter, "cppLanguageStandard", "CXX_STANDARD_TO_USE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "(default)";
                                     if (value == "stdcpp14")
@@ -1988,9 +1973,7 @@ int main(int argc, char* argv[])
       if (exporterType == "LINUX_MAKE")
       {
         convertSettingIfDefined(exporter, "cppLanguageStandard", "CXX_STANDARD_TO_USE",
-                                [](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [](const juce::String& value) -> juce::String {
                                   if (value == "-std=c++03")
                                     return "C++03";
 
@@ -2004,8 +1987,8 @@ int main(int argc, char* argv[])
                                 });
 
         convertSettingAsListIfDefined(
-          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::var& v) {
-            return juce::StringArray::fromTokens(v.toString(), " ", "\"'");
+          exporter, "linuxExtraPkgConfig", "PKGCONFIG_LIBRARIES", [](const juce::String& value) {
+            return juce::StringArray::fromTokens(value, " ", "\"'");
           });
       }
 
@@ -2020,9 +2003,7 @@ int main(int argc, char* argv[])
         };
 
         convertSettingIfDefined(exporter, "codeBlocksWindowsTarget", "TARGET_PLATFORM",
-                                [&windowsTargets](const juce::var& v) -> juce::String {
-                                  const auto value = v.toString();
-
+                                [&windowsTargets](const juce::String& value) -> juce::String {
                                   auto search = windowsTargets.find(value);
                                   if (search != windowsTargets.end())
                                   {
@@ -2064,9 +2045,7 @@ int main(int argc, char* argv[])
 
         const auto convertSearchPaths =
           [&isAbsolutePath, &jucerFileDir,
-           &targetProjectDir](const juce::var& v) -> juce::StringArray {
-          const auto searchPaths = v.toString();
-
+           &targetProjectDir](const juce::String& searchPaths) -> juce::StringArray {
           if (searchPaths.isEmpty())
           {
             return {};
@@ -2104,7 +2083,7 @@ int main(int argc, char* argv[])
 
         convertSettingAsListIfDefined(
           configuration, "defines", "PREPROCESSOR_DEFINITIONS",
-          [](const juce::var& v) { return parsePreprocessorDefinitions(v.toString()); });
+          [](const juce::String& value) { return parsePreprocessorDefinitions(value); });
 
         convertOnOffSettingIfDefined(configuration, "linkTimeOptimisation",
                                      "LINK_TIME_OPTIMISATION", {});
@@ -2113,8 +2092,8 @@ int main(int argc, char* argv[])
             && jucerVersionAsTuple >= Version{5, 2, 0})
         {
           convertOnOffSettingIfDefined(configuration, "wholeProgramOptimisation",
-                                       "LINK_TIME_OPTIMISATION", [](const juce::var& v) {
-                                         if (v.toString().getIntValue() == 0)
+                                       "LINK_TIME_OPTIMISATION", [](const juce::String& value) {
+                                         if (value.getIntValue() == 0)
                                            return "ON";
 
                                          return "OFF";
@@ -2125,9 +2104,7 @@ int main(int argc, char* argv[])
         {
           convertSettingIfDefined(configuration, "recommendedWarnings",
                                   "ADD_RECOMMENDED_COMPILER_WARNING_FLAGS",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "LLVM")
                                       return "Enabled";
 
@@ -2142,9 +2119,7 @@ int main(int argc, char* argv[])
         {
           convertSettingIfDefined(configuration, "recommendedWarnings",
                                   "ADD_RECOMMENDED_COMPILER_WARNING_FLAGS",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "GCC")
                                       return "GCC";
 
@@ -2162,10 +2137,10 @@ int main(int argc, char* argv[])
         }
 
         convertSettingIfDefined(configuration, "optimisation", "OPTIMISATION",
-                                [&isVSExporter](const juce::var& v) -> juce::String {
+                                [&isVSExporter](const juce::String& value) -> juce::String {
                                   if (isVSExporter)
                                   {
-                                    switch (v.toString().getIntValue())
+                                    switch (value.getIntValue())
                                     {
                                     case 1:
                                       return "No optimisation";
@@ -2178,7 +2153,7 @@ int main(int argc, char* argv[])
                                     return {};
                                   }
 
-                                  switch (v.toString().getIntValue())
+                                  switch (value.getIntValue())
                                   {
                                   case 1:
                                     return "-O0 (no optimisation)";
@@ -2266,9 +2241,7 @@ int main(int argc, char* argv[])
           };
 
           convertSettingIfDefined(configuration, "osxSDK", "OSX_BASE_SDK_VERSION",
-                                  [&sdks](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [&sdks](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2280,9 +2253,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(configuration, "osxCompatibility",
                                   "OSX_DEPLOYMENT_TARGET",
-                                  [&sdks](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [&sdks](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2293,9 +2264,7 @@ int main(int argc, char* argv[])
                                   });
 
           convertSettingIfDefined(configuration, "osxArchitecture", "OSX_ARCHITECTURE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value == "default")
                                       return "Use Default";
 
@@ -2319,8 +2288,8 @@ int main(int argc, char* argv[])
         {
           convertSettingAsListIfDefined(
             configuration, "customXcodeFlags", "CUSTOM_XCODE_FLAGS",
-            [](const juce::var& v) {
-              auto customFlags = juce::StringArray::fromTokens(v.toString(), ",", "\"'");
+            [](const juce::String& value) {
+              auto customFlags = juce::StringArray::fromTokens(value, ",", "\"'");
               customFlags.removeEmptyStrings();
 
               for (auto& flag : customFlags)
@@ -2334,15 +2303,13 @@ int main(int argc, char* argv[])
 
           convertSettingAsListIfDefined(
             configuration, "plistPreprocessorDefinitions",
-            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::var& v) {
-              return parsePreprocessorDefinitions(v.toString());
+            "PLIST_PREPROCESSOR_DEFINITIONS", [](const juce::String& value) {
+              return parsePreprocessorDefinitions(value);
             });
 
           convertSettingIfDefined(configuration, "cppLanguageStandard",
                                   "CXX_LANGUAGE_STANDARD",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Use Default";
 
@@ -2368,9 +2335,7 @@ int main(int argc, char* argv[])
                                   });
 
           convertSettingIfDefined(configuration, "cppLibType", "CXX_LIBRARY",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Use Default";
 
@@ -2416,8 +2381,8 @@ int main(int argc, char* argv[])
           }
 
           convertSettingIfDefined(configuration, "winWarningLevel", "WARNING_LEVEL",
-                                  [](const juce::var& v) -> juce::String {
-                                    switch (v.toString().getIntValue())
+                                  [](const juce::String& value) -> juce::String {
+                                    switch (value.getIntValue())
                                     {
                                     case 2:
                                       return "Low";
@@ -2434,9 +2399,7 @@ int main(int argc, char* argv[])
                                        "TREAT_WARNINGS_AS_ERRORS", {});
 
           convertSettingIfDefined(configuration, "useRuntimeLibDLL", "RUNTIME_LIBRARY",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "(Default)";
 
@@ -2453,11 +2416,11 @@ int main(int argc, char* argv[])
           {
             convertSettingIfDefined(configuration, "wholeProgramOptimisation",
                                     "WHOLE_PROGRAM_OPTIMISATION",
-                                    [](const juce::var& v) -> juce::String {
-                                      if (v.toString().isEmpty())
+                                    [](const juce::String& value) -> juce::String {
+                                      if (value.isEmpty())
                                         return "Enable when possible";
 
-                                      if (v.toString().getIntValue() > 0)
+                                      if (value.getIntValue() > 0)
                                         return "Always disable";
 
                                       return {};
@@ -2483,9 +2446,7 @@ int main(int argc, char* argv[])
                                        "GENERATE_MANIFEST", {});
 
           convertSettingIfDefined(configuration, "characterSet", "CHARACTER_SET",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "Default";
 
@@ -2508,9 +2469,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(
             configuration, "debugInformationFormat", "DEBUG_INFORMATION_FORMAT",
-            [](const juce::var& v) -> juce::String {
-              const auto value = v.toString();
-
+            [](const juce::String& value) -> juce::String {
               if (value == "None")
                 return "None";
 
@@ -2533,9 +2492,7 @@ int main(int argc, char* argv[])
         if (exporterType == "LINUX_MAKE")
         {
           convertSettingIfDefined(configuration, "linuxArchitecture", "ARCHITECTURE",
-                                  [](const juce::var& v) -> juce::String {
-                                    const auto value = v.toString();
-
+                                  [](const juce::String& value) -> juce::String {
                                     if (value.isEmpty())
                                       return "<None>";
 
@@ -2558,9 +2515,7 @@ int main(int argc, char* argv[])
                                   });
         }
 
-        const auto codeBlocksArchitecture = [](const juce::var& v) -> juce::String {
-          const auto value = v.toString();
-
+        const auto codeBlocksArchitecture = [](const juce::String& value) -> juce::String {
           if (value == "-m32")
             return "32-bit (-m32)";
 

--- a/Jucer2Reprojucer/main.cpp
+++ b/Jucer2Reprojucer/main.cpp
@@ -789,7 +789,8 @@ int main(int argc, char* argv[])
                             [](const juce::var& v) -> juce::String {
                               if (v.toString().isEmpty())
                                 return "Default";
-                              return juce::File::descriptionOfSizeInBytes(int{v});
+                              return juce::File::descriptionOfSizeInBytes(
+                                v.toString().getIntValue());
                             });
     if (jucerProject.hasProperty("includeBinaryInJuceHeader"))
     {
@@ -1248,9 +1249,9 @@ int main(int argc, char* argv[])
           {
             const auto& file = fileOrGroup;
 
-            files.push_back({int{file.getProperty("compile")} == 1,
-                             int{file.getProperty("xcodeResource")} == 1,
-                             int{file.getProperty("resource")} == 1,
+            files.push_back({file.getProperty("compile").toString().getIntValue() == 1,
+                             file.getProperty("xcodeResource").toString().getIntValue() == 1,
+                             file.getProperty("resource").toString().getIntValue() == 1,
                              file.getProperty("file").toString(),
                              file.getProperty("compilerFlagScheme").toString()});
           }
@@ -2101,7 +2102,7 @@ int main(int argc, char* argv[])
         {
           convertOnOffSettingIfDefined(configuration, "wholeProgramOptimisation",
                                        "LINK_TIME_OPTIMISATION", [](const juce::var& v) {
-                                         if (int{v} == 0)
+                                         if (v.toString().getIntValue() == 0)
                                            return "ON";
 
                                          return "OFF";
@@ -2152,7 +2153,7 @@ int main(int argc, char* argv[])
                                 [&isVSExporter](const juce::var& v) -> juce::String {
                                   if (isVSExporter)
                                   {
-                                    switch (int{v})
+                                    switch (v.toString().getIntValue())
                                     {
                                     case 1:
                                       return "No optimisation";
@@ -2165,7 +2166,7 @@ int main(int argc, char* argv[])
                                     return {};
                                   }
 
-                                  switch (int{v})
+                                  switch (v.toString().getIntValue())
                                   {
                                   case 1:
                                     return "-O0 (no optimisation)";
@@ -2404,7 +2405,7 @@ int main(int argc, char* argv[])
 
           convertSettingIfDefined(configuration, "winWarningLevel", "WARNING_LEVEL",
                                   [](const juce::var& v) -> juce::String {
-                                    switch (int{v})
+                                    switch (v.toString().getIntValue())
                                     {
                                     case 2:
                                       return "Low";
@@ -2444,7 +2445,7 @@ int main(int argc, char* argv[])
                                       if (v.toString().isEmpty())
                                         return "Enable when possible";
 
-                                      if (int{v} > 0)
+                                      if (v.toString().getIntValue() > 0)
                                         return "Always disable";
 
                                       return {};


### PR DESCRIPTION
This is an alternative to https://github.com/McMartin/FRUT/pull/631, which should hopefully be easier to review.

@MartyLake: please review, thanks!