### PR TITLE
Make "Getting Started" instructions work in Windows PowerShell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ We first build and install FRUT with CMake: ::
 
   $ mkdir build && cd build/
 
-  $ cmake .. -DCMAKE_INSTALL_PREFIX=../prefix -DJUCE_ROOT=../../JUCE
+  $ cmake .. -DCMAKE_INSTALL_PREFIX="../prefix" -DJUCE_ROOT="../../JUCE"
   ...
   -- Configuring done
   -- Generating done


### PR DESCRIPTION
This pull request contains a small tweak to "Getting Started" which I found necessary to build.

cmake version: 3.17.3
FRUT version: (latest master) https://github.com/McMartin/FRUT/commit/affc089b9f9e603e7a2b44ed15a0eef16ea0790d
JUCE version: (latest master) https://github.com/juce-framework/JUCE/commit/02bbe31c0d2fb59ed32fb725b56ad25536c7ed75

Commands were executed on the Visual Studio Code commandline.

Folder structure:
```
<root>
├── FRUT/
│   └── build/
├── JUCE/
└── MyGreatProject/
    ├── Source/
    └── MyGreatProject.jucer
```

In directory /FRUT/build/:
```
cmake .. -DCMAKE_INSTALL_PREFIX=../prefix -DJUCE_ROOT=../../JUCE
```
Resulted in error:
```
CMake Error: The source directory "D:/Dev/juce_projects/midi-fx/FRUT/prefix" does not exist.
```
My first instinct was to add the prefix directory manually to see what happened next, however, that lead to more directory errors.

I discovered in the CMakeCache.txt that the variables CMAKE_INSTALL_PREFIX and JUCE_ROOT were defined as empty.

So I added quotes to the paths and suddenly it works.
```
$ cmake .. -DCMAKE_INSTALL_PREFIX="../prefix" -DJUCE_ROOT="../../JUCE"
```