### PR TITLE
"Getting Started" should specify Juce modules root when directing user to run Reprojucer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,9 +154,11 @@ Then we convert ``MyGreatProject.jucer`` to a new ``CMakeLists.txt`` file: ::
 
   $ cd <root>/MyGreatProject/
 
-  $ ../FRUT/prefix/FRUT/bin/Jucer2Reprojucer MyGreatProject.jucer ../FRUT/prefix/FRUT/cmake/Reprojucer.cmake
+  $ ../FRUT/prefix/FRUT/bin/Jucer2Reprojucer MyGreatProject.jucer ../FRUT/prefix/FRUT/cmake/Reprojucer.cmake --juce-modules="../JUCE/modules"
 
   <root>/MyGreatProject/CMakeLists.txt has been successfully generated.
+
+*Note that the* ``--juce-modules`` *argument is only necessary if* ``MyGreatProject.jucer`` *uses modules from the global "JUCE Modules" path set in Projucer.*
 
 Now we can build ``MyGreatProject`` using CMake: ::
 


### PR DESCRIPTION
"Getting Started" should specify Juce modules root when directing user to run Reprojucer

Otherwise an error is raised similar to:
error: The module juce_audio_basics requires a global path. You should pass the JUCE modules global path using --juce-modules.