### PR TITLE
Adapt to renaming default branch to "main"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - main
 
 clone_depth: 50
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
 
 jobs:
   - job: VS2017

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: clang-format
 
-  only_if: $CIRRUS_BASE_BRANCH == "master" || $CIRRUS_BRANCH == "master"
+  only_if: $CIRRUS_BASE_BRANCH == "main" || $CIRRUS_BRANCH == "main"
 
   container:
     image: rsmmr/clang:9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - main
 
 language: cpp
 

--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ contributors:
       <br />
       <a href="https://github.com/McMartin/FRUT/pulls?q=state%3Amerged+author%3AMcMartin" title="Code">💻</a>
       <a href="https://github.com/McMartin/FRUT/pulls?q=state%3Amerged+reviewed-by%3AMcMartin+-author%3AMcMartin+" title="Pull Request reviews">👀</a>
-      <a href="https://github.com/McMartin/FRUT/commits/master/docs?author=McMartin" title="Documentation">📖</a>
+      <a href="https://github.com/McMartin/FRUT/commits/main/docs?author=McMartin" title="Documentation">📖</a>
     </td>
     <td>
       <a href="https://github.com/MartyLake"><img src="https://github.com/MartyLake.png" width="100"><br />Matthieu Talbot</a>
@@ -360,15 +360,15 @@ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
   :target: CODE_OF_CONDUCT.md
   :alt: Contributor Covenant Code of Conduct
 
-.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/McMartin/frut?branch=master&svg=true
+.. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/McMartin/frut?branch=main&svg=true
   :target: https://ci.appveyor.com/project/McMartin/frut
   :alt: AppVeyor build status
 
-.. |Azure_Pipelines| image:: https://dev.azure.com/McMartin/FRUT/_apis/build/status/McMartin.FRUT?branchName=master
+.. |Azure_Pipelines| image:: https://dev.azure.com/McMartin/FRUT/_apis/build/status/McMartin.FRUT?branchName=main
   :target: https://dev.azure.com/McMartin/FRUT/_build?definitionId=2
   :alt: Azure Pipelines build status
 
-.. |Travis_CI| image:: https://travis-ci.org/McMartin/FRUT.svg?branch=master
+.. |Travis_CI| image:: https://travis-ci.org/McMartin/FRUT.svg?branch=main
   :target: https://travis-ci.org/McMartin/FRUT
   :alt: Travis CI build status
 

--- a/docs/Reprojucer.cmake/command/jucer_appconfig_header.rst
+++ b/docs/Reprojucer.cmake/command/jucer_appconfig_header.rst
@@ -31,7 +31,7 @@ Example
 -------
 
 From `the AudioPluginHost extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.4.3/extras/AudioPluginHost/CMakeLists.txt#L185-L192>`_:
+main/generated/JUCE-5.4.3/extras/AudioPluginHost/CMakeLists.txt#L185-L192>`_:
 
 .. code-block:: cmake
   :lineno-start: 185

--- a/docs/Reprojucer.cmake/command/jucer_audio_plugin_settings.rst
+++ b/docs/Reprojucer.cmake/command/jucer_audio_plugin_settings.rst
@@ -74,8 +74,7 @@ Example
 -------
 
 From `the MultiOutSynth example of JUCE 5.2.1 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.2.1/examples/PlugInSamples/MultiOutSynth/CMakeLists.txt
-#L42-L68>`_:
+main/generated/JUCE-5.2.1/examples/PlugInSamples/MultiOutSynth/CMakeLists.txt#L42-L68>`_:
 
 .. code-block:: cmake
   :lineno-start: 42

--- a/docs/Reprojucer.cmake/command/jucer_export_target.rst
+++ b/docs/Reprojucer.cmake/command/jucer_export_target.rst
@@ -128,7 +128,7 @@ Examples
 --------
 
 From `the AudioPluginHost extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.4.3/extras/AudioPluginHost/CMakeLists.txt#L194-L208>`_:
+main/generated/JUCE-5.4.3/extras/AudioPluginHost/CMakeLists.txt#L194-L208>`_:
 
 .. code-block:: cmake
   :lineno-start: 194
@@ -150,7 +150,7 @@ master/generated/JUCE-5.4.3/extras/AudioPluginHost/CMakeLists.txt#L194-L208>`_:
   )
 
 
-From `the DemoRunner example of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/master/
+From `the DemoRunner example of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/main/
 generated/JUCE-5.4.3/examples/DemoRunner/CMakeLists.txt#L372-L380>`_:
 
 .. code-block:: cmake
@@ -168,7 +168,7 @@ generated/JUCE-5.4.3/examples/DemoRunner/CMakeLists.txt#L372-L380>`_:
 
 
 From `the Projucer extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.4.3/extras/Projucer/CMakeLists.txt#L719-L724>`_:
+main/generated/JUCE-5.4.3/extras/Projucer/CMakeLists.txt#L719-L724>`_:
 
 .. code-block:: cmake
   :lineno-start: 719

--- a/docs/Reprojucer.cmake/command/jucer_export_target_configuration.rst
+++ b/docs/Reprojucer.cmake/command/jucer_export_target_configuration.rst
@@ -106,7 +106,7 @@ Examples
 --------
 
 From `the NetworkGraphicsDemo extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.4.3/extras/NetworkGraphicsDemo/CMakeLists.txt#L176-L182>`_:
+main/generated/JUCE-5.4.3/extras/NetworkGraphicsDemo/CMakeLists.txt#L176-L182>`_:
 
 .. code-block:: cmake
   :lineno-start: 176
@@ -121,7 +121,7 @@ master/generated/JUCE-5.4.3/extras/NetworkGraphicsDemo/CMakeLists.txt#L176-L182>
 
 
 From `the UnitTestRunner extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.4.3/extras/UnitTestRunner/CMakeLists.txt#L277-L284>`_:
+main/generated/JUCE-5.4.3/extras/UnitTestRunner/CMakeLists.txt#L277-L284>`_:
 
 .. code-block:: cmake
   :lineno-start: 277
@@ -136,7 +136,7 @@ master/generated/JUCE-5.4.3/extras/UnitTestRunner/CMakeLists.txt#L277-L284>`_:
   )
 
 
-From `the Projucer extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/master/
+From `the Projucer extra of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/main/
 generated/JUCE-5.4.3/extras/Projucer/CMakeLists.txt#L726-L733>`_:
 
 .. code-block:: cmake

--- a/docs/Reprojucer.cmake/command/jucer_project_files.rst
+++ b/docs/Reprojucer.cmake/command/jucer_project_files.rst
@@ -37,7 +37,7 @@ sub-group of ``A/B``.
 Example
 -------
 
-From `the AUv3Synth example of JUCE 5.2.1 <https://github.com/McMartin/FRUT/blob/master/
+From `the AUv3Synth example of JUCE 5.2.1 <https://github.com/McMartin/FRUT/blob/main/
 generated/JUCE-5.2.1/examples/AUv3Synth/CMakeLists.txt#L68-L82>`_:
 
 .. code-block:: cmake

--- a/docs/Reprojucer.cmake/command/jucer_project_module.rst
+++ b/docs/Reprojucer.cmake/command/jucer_project_module.rst
@@ -40,7 +40,7 @@ Example
 -------
 
 From `the Plugin Host example of JUCE 5.2.1 <https://github.com/McMartin/FRUT/blob/
-master/generated/JUCE-5.2.1/examples/audio%20plugin%20host/CMakeLists.txt#L86-L99>`_:
+main/generated/JUCE-5.2.1/examples/audio%20plugin%20host/CMakeLists.txt#L86-L99>`_:
 
 .. code-block:: cmake
   :lineno-start: 86

--- a/docs/Reprojucer.cmake/command/jucer_project_settings.rst
+++ b/docs/Reprojucer.cmake/command/jucer_project_settings.rst
@@ -58,7 +58,7 @@ Define the settings specific to a JUCE project.
 Example
 -------
 
-From `the DemoRunner example of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/master/
+From `the DemoRunner example of JUCE 5.4.3 <https://github.com/McMartin/FRUT/blob/main/
 generated/JUCE-5.4.3/examples/DemoRunner/CMakeLists.txt#L28-L43>`_:
 
 .. code-block:: cmake

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,11 +73,11 @@ User documentation
 .. _JUCE 6.0.1: https://github.com/juce-framework/JUCE/tree/6.0.1
 .. _JUCE: https://github.com/juce-framework/JUCE
 .. _Projucer: https://juce.com/discover/projucer
-.. _generated/JUCE-4.2.0: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-4.2.0
-.. _generated/JUCE-4.3.1: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-4.3.1
-.. _generated/JUCE-5.0.0: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-5.0.0
-.. _generated/JUCE-5.2.1: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-5.2.1
-.. _generated/JUCE-5.3.1: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-5.3.1
-.. _generated/JUCE-5.4.3: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-5.4.3
-.. _generated/JUCE-5.4.7: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-5.4.7
-.. _generated/JUCE-6.0.1: https://github.com/McMartin/FRUT/tree/master/generated/JUCE-6.0.1
+.. _generated/JUCE-4.2.0: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-4.2.0
+.. _generated/JUCE-4.3.1: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-4.3.1
+.. _generated/JUCE-5.0.0: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-5.0.0
+.. _generated/JUCE-5.2.1: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-5.2.1
+.. _generated/JUCE-5.3.1: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-5.3.1
+.. _generated/JUCE-5.4.3: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-5.4.3
+.. _generated/JUCE-5.4.7: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-5.4.7
+.. _generated/JUCE-6.0.1: https://github.com/McMartin/FRUT/tree/main/generated/JUCE-6.0.1


### PR DESCRIPTION
I already changed the default branch of this repository from `master` to `main`. This PR adapts the code.

@MartyLake: please review, thanks!