### PR TITLE
Fix building IconBuilder when using latest VS2019 (16.10+)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,23 @@ contributors:
       <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Abenediktsailer" title="Bug reports">🐛</a>
     </td>
   </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/steve-baker-cradle"><img src="https://github.com/steve-baker-cradle.png" width="100"><br />Steve Baker</a>
+      <br />
+      <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Asteve-baker-cradle" title="Bug reports">🐛</a>
+    </td>
+    <td>
+    </td>
+    <td>
+    </td>
+    <td>
+    </td>
+    <td>
+    </td>
+    <td>
+    </td>
+  </tr>
   </tbody>
   </table>
 

--- a/cmake/tools/juce_gui_basics.cmake
+++ b/cmake/tools/juce_gui_basics.cmake
@@ -65,6 +65,10 @@ if(APPLE)
   )
 endif()
 
+if(MSVC)
+  target_compile_options(tools_juce_gui_basics PRIVATE /bigobj)
+endif()
+
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   find_package(PkgConfig REQUIRED)
 


### PR DESCRIPTION
Resolves #684 

@MartyLake: please review, thanks!

@steve-baker-cradle: please have a look at the second commit (602ece83b55f2c91677e6b1460d65dbd2068f94c) and let me know whether what I wrote is correct. Thanks!