### PR TITLE
Check formatting of .hpp files on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,6 +8,6 @@ task:
 
   test_script:
     - clang-format -version
-    - 'git ls-files {Jucer2CMake/src,cmake/tools}/"*."{cpp,h}
+    - 'git ls-files {Jucer2CMake/src,cmake/tools}/"*."{cpp,h,hpp}
       | xargs -d\\n clang-format -i -style=file -verbose'
     - git diff --exit-code


### PR DESCRIPTION
As @Riuzakiii found out, the formatting of `Jucer2CMake/src/reprojucer.hpp` and other `.hpp` files was not checked on CI.