### PR TITLE
Trim potential whitespaces when extracting module options

### DIFF
--- a/Jucer2CMake/src/reprojucer.hpp
+++ b/Jucer2CMake/src/reprojucer.hpp
@@ -1273,7 +1273,7 @@ inline void writeReprojucerCMakeLists(const Arguments& args,
       {
         if (line.startsWith("/** Config: "))
         {
-          const auto moduleOption = line.substring(12);
+          const auto moduleOption = line.substring(12).trim();
           const auto& optionValue = modulesOptions.getStringAttribute(moduleOption);
 
           if (optionValue == "1" || optionValue == "enabled")


### PR DESCRIPTION
Fixes https://github.com/McMartin/FRUT/issues/747