### PR TITLE
Fix generating shell scripts with variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -388,6 +388,9 @@ contributors:
       <a href="https://github.com/McMartin/FRUT/issues?q=is%3Aissue+author%3Ahsetlik" title="Bug reports">🐛</a>
     </td>
     <td>
+      <a href="https://github.com/aostrowski"><img src="https://github.com/aostrowski.png" width="100"><br />Adrian Ostrowski</a>
+      <br />
+      <a href="https://github.com/McMartin/FRUT/pulls?q=state%3Amerged+author%3Aaostrowski" title="Code">💻</a>
     </td>
     <td>
     </td>


### PR DESCRIPTION
JUCE projects allow using shell script, for instance when defining post
build actions. When the shell script referred to variables using braced
notation, e. g. ${PULP}, FRUT made CMake resolve such a variable at
build system generation time instead of at build time.

For instance, given the following Post-Build Shell Script:

```
VAR="It works!"
echo "${VAR}"
```

we will end up with a postbuild.sh file with the following content:

```
VAR="It works!"
echo ""
```

As CMake will recognize `${VAR}` as a variable reference and will
immediately resolve it. The following script would works fine:

```
VAR="It works!"
echo "$VAR"
```

but the former is still a properly written shell script.

This commit treats the shell scripts as bracket arguments instead of
quoted arguments to fix this issue.